### PR TITLE
Update print_repo to accept flexible github paths

### DIFF
--- a/tests/test_print_repo_positional.py
+++ b/tests/test_print_repo_positional.py
@@ -6,9 +6,10 @@ import pytest
 from prin.core import DepthFirstPrinter
 from prin.formatters import XmlFormatter
 from prin.adapters.github import GitHubRepoSource
+from prin.print_repo import _extract_in_repo_subpath
 
 
-def _run_repo(url: str, subpaths: list[str]) -> str:
+def _run_repo(url: str, subpaths: list[str] | None = None) -> str:
     class _Buf:
         def __init__(self) -> None:
             self.parts: list[str] = []
@@ -27,15 +28,24 @@ def _run_repo(url: str, subpaths: list[str]) -> str:
         exclude=[],
     )
     buf = _Buf()
-    p.run(subpaths or [""], buf)
+    # Derive initial root from URL if a subpath is embedded; allow explicit extra roots
+    derived = _extract_in_repo_subpath(url).strip("/")
+    roots: list[str] = []
+    if derived:
+        roots.append(derived)
+    if subpaths:
+        roots.extend(subpaths)
+    if not roots:
+        roots = [""]
+    p.run(roots, buf)
     return buf.text()
 
 
 @pytest.mark.timeout(15)
 def test_repo_explicit_ignored_file_is_printed():
     # LICENSE has no extension; treat it as ignored by default, but explicit path must print it
-    url = "https://github.com/TypingMind/awesome-typingmind"
-    out = _run_repo(url, ["LICENSE"])  # GitHub path semantics
+    url = "https://github.com/TypingMind/awesome-typingmind/LICENSE"
+    out = _run_repo(url)  # Path embedded in URL
     assert "<LICENSE>" in out
 
 
@@ -51,9 +61,9 @@ def test_two_repositories_print_both():
 
 @pytest.mark.timeout(15)
 def test_repo_dir_and_explicit_ignored_file():
-    url = "https://github.com/TypingMind/awesome-typingmind"
-    # Traverse repo root and also explicitly include LICENSE
-    out = _run_repo(url, ["", "LICENSE"])  # default root + explicit path
+    # Embed LICENSE in URL, and also traverse repo root by adding an empty root
+    url = "https://github.com/TypingMind/awesome-typingmind/LICENSE"
+    out = _run_repo(url, [""])  # default root + embedded explicit path
     assert "<README.md>" in out  # normal traversal still prints repo files
     assert "<LICENSE>" in out    # explicit inclusion prints extensionless file
 


### PR DESCRIPTION
Allow `print_repo` to extract repository subpaths from GitHub URLs, automatically ignoring `blob/` and default branch segments for user convenience.

---
<a href="https://cursor.com/background-agent?bcId=bc-c728e075-094f-47b6-b35d-7b1f4f53ad90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c728e075-094f-47b6-b35d-7b1f4f53ad90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

