### PR TITLE
Compare CLI options to roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Engine-driven depth-first traversal with source adapters; the engine is source-a
 - GitHub: list via Contents API; for file paths, raise NotADirectoryError so engine force-includes; ignore local .gitignore for repos.
 
 ### CLI and flags
-- One shared parser in `cli_common` used by both implementations; no interactive prompts; consistent flags (`-t`, `-x`, `--no-ignore`, `-E`, `-l`, etc.).
+- One shared parser in `cli_common` used by both implementations; no interactive prompts; consistent flags (`-e`, `-E`, `--no-ignore`, `-l`, etc.).
 - `prin` dispatches: GitHub URL → repo implementation; otherwise filesystem. Keep URL detection minimal and robust.
 
 ### Filtering semantics

--- a/README.md
+++ b/README.md
@@ -99,5 +99,8 @@ Print absolute paths (instead of paths relative to the current working directory
 - `-a`, `--text`
 Treat binary files as text (search and print them as-is).
 
+- `--binary`, `--include-binary`
+Include binary files in the output (e.g., *.pyc, images, archives). Binary files are emitted as headers only in some formats.
+
 - `-n`, `--line-number` (alias: `--line-numbers`)
 Show line numbers in printed file contents.

--- a/src/prin/cli_common.py
+++ b/src/prin/cli_common.py
@@ -19,7 +19,7 @@ def parse_common_args(
     epilog = textwrap.dedent(
         f"""
         DEFAULT MATCH CRITERIA
-        When -t,--type is unspecified, the following file extensions are matched: {", ".join(resolve_extensions(custom_extensions=[], no_docs=False))}.
+        When -e,--extension is unspecified, the following file extensions are matched: {", ".join(resolve_extensions(custom_extensions=[], no_docs=False))}.
 
         NOTE ABOUT EXCLUSIONS
         Exclusions match rather eagerly, because each specified exclusion is handled like a substring match. For example, 'o/b' matches 'foo/bar/baz'.
@@ -69,7 +69,7 @@ def parse_common_args(
         "-d",
         "--no-docs",
         action="store_true",
-        help="Exclude `.md`, `.mdx` and `.rst` files. Has no effect if -t,--type is specified.",
+        help="Exclude `.md`, `.mdx` and `.rst` files. Has no effect if -e,--extension is specified.",
     )
     parser.add_argument(
         "-M",
@@ -81,14 +81,12 @@ def parse_common_args(
         "-l", "--only-headers", action="store_true", help="Print only the file paths."
     )
     parser.add_argument(
-        "-t",
-        "--type",
         "-e",
         "--extension",
         type=str,
         default=[],
         action="append",
-        help="Match only files with the given extensions or glob patterns. Can be specified multiple times.",
+        help="Only include files with the given extension (repeatable).",
     )
     # Lazy import remaining helpers for help text
     from .print_files import (
@@ -97,12 +95,11 @@ def parse_common_args(
     )
 
     parser.add_argument(
-        "-x",
         "-E",
         "--exclude",
         "--ignore",
         type=str,
-        help="Exclude files or directories whose path contains the given name/path or matches the given glob. Can be specified multiple times. By default, excludes "
+        help="Exclude files or directories by shell-style glob or regex (repeatable). By default, excludes "
         + ", ".join(map(_describe_predicate, DEFAULT_EXCLUSIONS))
         + ", and any files in .gitignore, .git/info/exclude, and ~/.config/git/ignore.",
         default=[],
@@ -130,7 +127,7 @@ def derive_filters_and_print_flags(args) -> tuple[list[str], list, bool, bool]:
     # Lazy import to avoid cycles
     from .print_files import resolve_exclusions, resolve_extensions  # type: ignore
 
-    extensions = resolve_extensions(custom_extensions=args.type, no_docs=args.no_docs)
+    extensions = resolve_extensions(custom_extensions=args.extension, no_docs=args.no_docs)
     exclusions = resolve_exclusions(
         no_exclude=args.no_exclude,
         custom_excludes=args.exclude,

--- a/src/prin/cli_common.py
+++ b/src/prin/cli_common.py
@@ -51,7 +51,7 @@ def parse_common_args(
         help="Include `test` and `tests` directories and spec.ts files.",
     )
     parser.add_argument(
-        "-L",
+        "-K",
         "--include-lock",
         action="store_true",
         help="Include lock files (e.g. package-lock.json, poetry.lock, Cargo.lock).",
@@ -72,7 +72,7 @@ def parse_common_args(
         help="Exclude `.md`, `.mdx` and `.rst` files. Has no effect if -t,--type is specified.",
     )
     parser.add_argument(
-        "-E",
+        "-M",
         "--include-empty",
         action="store_true",
         help="Include empty files and files that only contain imports and __all__=... expressions.",
@@ -83,6 +83,8 @@ def parse_common_args(
     parser.add_argument(
         "-t",
         "--type",
+        "-e",
+        "--extension",
         type=str,
         default=[],
         action="append",
@@ -96,7 +98,9 @@ def parse_common_args(
 
     parser.add_argument(
         "-x",
+        "-E",
         "--exclude",
+        "--ignore",
         type=str,
         help="Exclude files or directories whose path contains the given name/path or matches the given glob. Can be specified multiple times. By default, excludes "
         + ", ".join(map(_describe_predicate, DEFAULT_EXCLUSIONS))


### PR DESCRIPTION
Align CLI options with the roadmap and update the README to reflect binary file handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-a537e09f-dc60-4b86-86b4-7d4353ad5a03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a537e09f-dc60-4b86-86b4-7d4353ad5a03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

