### PR TITLE
Unskip and fix failing test

### DIFF
--- a/src/prin/prin.py
+++ b/src/prin/prin.py
@@ -20,13 +20,15 @@ def main(*, argv: list[str] | None = None, writer: Writer | None = None) -> None
     out_writer = writer or StdoutWriter()
 
     # Split positional inputs into local paths and GitHub URLs
+    # Treat empty-string tokens as no-ops for local paths to avoid unintended CWD traversal
     local_paths: list[str] = []
     repo_urls: list[str] = []
     for tok in ctx.paths:
         if is_github_url(tok):
             repo_urls.append(tok)
         else:
-            local_paths.append(tok)
+            if tok != "":
+                local_paths.append(tok)
 
     # Filesystem chunk (if any)
     if local_paths:

--- a/tests/test_print_repo_positional.py
+++ b/tests/test_print_repo_positional.py
@@ -44,7 +44,6 @@ def test_pass_two_repositories_positionally_print_both():
     assert "<Cargo.toml>" in out
 
 
-@pytest.mark.skip(reason="Failing. If fixed, should be a deliberate decision.")
 def test_repo_dir_and_explicit_ignored_file():
     # Embed LICENSE in URL, and also traverse repo root by adding an empty root
     url = "https://github.com/TypingMind/awesome-typingmind/LICENSE"


### PR DESCRIPTION
Unskip `test_repo_dir_and_explicit_ignored_file` and fix `prin.prin.main` to ignore empty-string local path tokens.

The `test_repo_dir_and_explicit_ignored_file` test, when unskipped, failed because an empty string token in the positional arguments was incorrectly interpreted as a local path representing the current working directory. This could lead to unintended file system traversal, especially when a repo URL also included an embedded path. The fix ensures that empty strings are not treated as valid local paths, preventing this erroneous behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-4081d4d6-ab62-43c2-aa7b-e2f5098422eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4081d4d6-ab62-43c2-aa7b-e2f5098422eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

