### PR TITLE
Add max files option to prin

### DIFF
--- a/src/prin/cli_common.py
+++ b/src/prin/cli_common.py
@@ -41,6 +41,7 @@ class Context:
     no_exclude: bool = DEFAULT_NO_EXCLUDE
     no_ignore: bool = DEFAULT_NO_IGNORE
     tag: Literal["xml", "md"] = DEFAULT_TAG
+    max_files: int | None = None
 
 
 def parse_common_args(argv: list[str] | None = None) -> Context:
@@ -160,6 +161,14 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         help="Output format tag: 'xml' or 'md'.",
     )
 
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        dest="max_files",
+        default=None,
+        help="Maximum number of files to print across all inputs.",
+    )
+
     args = parser.parse_args(argv)
     return Context(
         paths=list(args.paths),
@@ -174,6 +183,7 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         no_exclude=bool(args.no_exclude),
         no_ignore=bool(args.no_ignore),
         tag=args.tag,
+        max_files=args.max_files,
     )
 
 

--- a/src/prin/core.py
+++ b/src/prin/core.py
@@ -126,7 +126,7 @@ class StringWriter(Writer):
         return "".join(self._parts)
 
 
-class PrintBudget:
+class FileBudget:
     """
     Global print-budget shared across sources. Each printed file consumes 1 unit.
     When exhausted, traversal and printing should stop as early as possible.
@@ -172,7 +172,7 @@ class DepthFirstPrinter:
         self._pf_is_excluded: Callable[[object, list], bool] = _filters.is_excluded
         self._pf_is_glob: Callable[[object], bool] = _filters.is_glob
 
-    def run(self, roots: list[str], writer: Writer, budget: "PrintBudget | None" = None) -> None:
+    def run(self, roots: list[str], writer: Writer, budget: "FileBudget | None" = None) -> None:
         for root_spec in roots or ["."]:
             if budget is not None and budget.spent():
                 return
@@ -230,7 +230,7 @@ class DepthFirstPrinter:
         *,
         base: PurePosixPath,
         force: bool = False,
-        budget: "PrintBudget | None" = None,
+        budget: "FileBudget | None" = None,
     ) -> None:
         # Avoid duplicate prints when a file is both an explicit root and encountered during traversal
         key = str(entry.path)

--- a/src/prin/prin.py
+++ b/src/prin/prin.py
@@ -5,7 +5,7 @@ import sys
 from .adapters.filesystem import FileSystemSource
 from .adapters.github import GitHubRepoSource
 from .cli_common import Context, derive_filters_and_print_flags, parse_common_args
-from .core import DepthFirstPrinter, PrintBudget, StdoutWriter, Writer
+from .core import DepthFirstPrinter, FileBudget, StdoutWriter, Writer
 from .formatters import MarkdownFormatter, XmlFormatter
 from .util import extract_in_repo_subpath, is_github_url
 
@@ -31,7 +31,7 @@ def main(*, argv: list[str] | None = None, writer: Writer | None = None) -> None
                 local_paths.append(tok)
 
     # Global print budget shared across sources
-    budget = PrintBudget(ctx.max_files)
+    budget = FileBudget(ctx.max_files)
 
     # Filesystem chunk (if any)
     if local_paths:

--- a/src/prin/print_files.py
+++ b/src/prin/print_files.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .adapters.filesystem import FileSystemSource
 from .cli_common import Context, derive_filters_and_print_flags, parse_common_args
-from .core import DepthFirstPrinter, StdoutWriter, Writer
+from .core import DepthFirstPrinter, PrintBudget, StdoutWriter, Writer
 from .formatters import MarkdownFormatter, XmlFormatter
 
 
@@ -20,7 +20,8 @@ def main(*, argv: list[str] | None = None, writer: Writer | None = None) -> None
         exclude=exclusions,
     )
     out_writer = writer or StdoutWriter()
-    printer.run(ctx.paths, out_writer)
+    budget = PrintBudget(ctx.max_files)
+    printer.run(ctx.paths, out_writer, budget=budget)
 
 
 def matches(argv: list[str]) -> bool:

--- a/src/prin/print_files.py
+++ b/src/prin/print_files.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .adapters.filesystem import FileSystemSource
 from .cli_common import Context, derive_filters_and_print_flags, parse_common_args
-from .core import DepthFirstPrinter, PrintBudget, StdoutWriter, Writer
+from .core import DepthFirstPrinter, FileBudget, StdoutWriter, Writer
 from .formatters import MarkdownFormatter, XmlFormatter
 
 
@@ -20,7 +20,7 @@ def main(*, argv: list[str] | None = None, writer: Writer | None = None) -> None
         exclude=exclusions,
     )
     out_writer = writer or StdoutWriter()
-    budget = PrintBudget(ctx.max_files)
+    budget = FileBudget(ctx.max_files)
     printer.run(ctx.paths, out_writer, budget=budget)
 
 

--- a/src/prin/print_repo.py
+++ b/src/prin/print_repo.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .adapters.github import GitHubRepoSource
 from .cli_common import Context, derive_filters_and_print_flags, parse_common_args
-from .core import DepthFirstPrinter, StdoutWriter, Writer
+from .core import DepthFirstPrinter, PrintBudget, StdoutWriter, Writer
 from .defaults import DEFAULT_RUN_PATH
 from .formatters import MarkdownFormatter, XmlFormatter
 from .util import extract_in_repo_subpath, is_github_url
@@ -63,7 +63,8 @@ def main(
     )
 
     out_writer = writer or StdoutWriter()
-    printer.run(ctx.paths, out_writer)
+    budget = PrintBudget(ctx.max_files)
+    printer.run(ctx.paths, out_writer, budget=budget)
 
 
 def matches(argv: list[str]) -> bool:

--- a/src/prin/print_repo.py
+++ b/src/prin/print_repo.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .adapters.github import GitHubRepoSource
 from .cli_common import Context, derive_filters_and_print_flags, parse_common_args
-from .core import DepthFirstPrinter, PrintBudget, StdoutWriter, Writer
+from .core import DepthFirstPrinter, FileBudget, StdoutWriter, Writer
 from .defaults import DEFAULT_RUN_PATH
 from .formatters import MarkdownFormatter, XmlFormatter
 from .util import extract_in_repo_subpath, is_github_url
@@ -63,7 +63,7 @@ def main(
     )
 
     out_writer = writer or StdoutWriter()
-    budget = PrintBudget(ctx.max_files)
+    budget = FileBudget(ctx.max_files)
     printer.run(ctx.paths, out_writer, budget=budget)
 
 

--- a/tests/test_max_files_fs.py
+++ b/tests/test_max_files_fs.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from prin.core import StringWriter
+from prin.prin import main as prin_main
+
+
+def _write(p: Path, content: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def _count_opening_xml_tags(text: str) -> int:
+    return sum(
+        1
+        for line in text.splitlines()
+        if line.startswith("<") and not line.startswith("</") and not line.endswith("/>")
+    )
+
+
+def test_max_files_limits_printed_files_all_included(tmp_path: Path):
+    # Build a small tree with 5 printable files
+    _write(tmp_path / "a.py", "print('a')\n")
+    _write(tmp_path / "b.py", "print('b')\n")
+    _write(tmp_path / "dir" / "c.py", "print('c')\n")
+    _write(tmp_path / "dir" / "d.py", "print('d')\n")
+    _write(tmp_path / "dir" / "sub" / "e.py", "print('e')\n")
+
+    buf = StringWriter()
+    prin_main(argv=["--max-files", "4", str(tmp_path)], writer=buf)
+    out = buf.text()
+    assert _count_opening_xml_tags(out) == 4
+
+
+def test_max_files_skips_non_matching_and_still_prints_four(tmp_path: Path):
+    # 4 printable files and one .lock that should not match by default extensions
+    _write(tmp_path / "a.lock", "dummy\n")  # ensure it sorts early among files
+    _write(tmp_path / "a.py", "print('a')\n")
+    _write(tmp_path / "dir" / "b.py", "print('b')\n")
+    _write(tmp_path / "dir" / "c.py", "print('c')\n")
+    _write(tmp_path / "dir" / "sub" / "d.py", "print('d')\n")
+
+    buf = StringWriter()
+    prin_main(argv=["--max-files", "4", str(tmp_path)], writer=buf)
+    out = buf.text()
+    assert _count_opening_xml_tags(out) == 4
+

--- a/tests/test_max_files_fs.py
+++ b/tests/test_max_files_fs.py
@@ -28,7 +28,7 @@ def test_max_files_limits_printed_files_all_included(tmp_path: Path):
     _write(tmp_path / "dir" / "sub" / "e.py", "print('e')\n")
 
     buf = StringWriter()
-    prin_main(argv=["--max-files", "4", str(tmp_path)], writer=buf)
+    prin_main(argv=["--include-tests", "--max-files", "4", str(tmp_path)], writer=buf)
     out = buf.text()
     assert _count_opening_xml_tags(out) == 4
 
@@ -42,7 +42,7 @@ def test_max_files_skips_non_matching_and_still_prints_four(tmp_path: Path):
     _write(tmp_path / "dir" / "sub" / "d.py", "print('d')\n")
 
     buf = StringWriter()
-    prin_main(argv=["--max-files", "4", str(tmp_path)], writer=buf)
+    prin_main(argv=["--include-tests", "--max-files", "4", str(tmp_path)], writer=buf)
     out = buf.text()
     assert _count_opening_xml_tags(out) == 4
 

--- a/tests/test_max_files_repo.py
+++ b/tests/test_max_files_repo.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from prin.core import StringWriter
+from prin.prin import main as prin_main
+
+
+@pytest.fixture(autouse=True)
+def _ensure_github_token(monkeypatch):
+    # If not set, try to load from ~/.github-token to avoid rate limits
+    if os.environ.get("GITHUB_TOKEN"):
+        return
+    token_path = Path.home() / ".github-token"
+    try:
+        token = token_path.read_text().strip()
+    except Exception:
+        token = ""
+    if token:
+        monkeypatch.setenv("GITHUB_TOKEN", token)
+
+
+def _count_md_headers(text: str) -> int:
+    return sum(1 for line in text.splitlines() if line.startswith("# FILE: "))
+
+
+def test_repo_max_files_one():
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    buf = StringWriter()
+    prin_main(argv=[url, "--max-files", "1", "--tag", "md"], writer=buf)
+    out = buf.text()
+    assert _count_md_headers(out) == 1
+

--- a/tmp_debug.py
+++ b/tmp_debug.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+from prin.core import StringWriter
+from prin.prin import main as prin_main
+
+base = Path('/tmp/prin-debug')
+base.mkdir(parents=True, exist_ok=True)
+(base/'a.py').write_text('print(1)\n', encoding='utf-8')
+(base/'b.py').write_text('print(2)\n', encoding='utf-8')
+
+buf = StringWriter()
+prin_main(argv=['--max-files','4', str(base)], writer=buf)
+out = buf.text()
+print('LEN', len(out))
+print(out)


### PR DESCRIPTION
Add a `--max-files` option to limit the total number of files printed across all inputs, preventing terminal spam and excessive GitHub API usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-112e1444-d8a3-4ea3-8b14-63d19fb38eec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-112e1444-d8a3-4ea3-8b14-63d19fb38eec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

