### PR TITLE
Handle extensionless files and fix markdown

### DIFF
--- a/src/prin/cli_common.py
+++ b/src/prin/cli_common.py
@@ -50,7 +50,7 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
     epilog = textwrap.dedent(
         f"""
         DEFAULT MATCH CRITERIA
-        When -e,--extension is unspecified, the following file extensions are matched: {", ".join(resolve_extensions(custom_extensions=[], no_docs=False))}.
+        When -e,--extension is unspecified, common source and documentation extensions are matched, plus extensionless files like LICENSE and Dockerfile.
 
         NOTE ABOUT EXCLUSIONS
         Exclusions match rather eagerly, because each specified exclusion is handled like a substring match. For example, 'o/b' matches 'foo/bar/baz'.

--- a/src/prin/core.py
+++ b/src/prin/core.py
@@ -219,7 +219,13 @@ class DepthFirstPrinter:
                 if fnmatch(filename, pattern):
                     return True
             else:
-                if filename.endswith("." + pattern.removeprefix(".")):
+                # Special-case sentinel for extensionless files
+                from .defaults import EXTENSIONLESS_SENTINEL as _EXT
+
+                if pattern == _EXT:
+                    if "." not in filename:
+                        return True
+                elif filename.endswith("." + pattern.removeprefix(".")):
                     return True
         return False
 

--- a/src/prin/defaults.py
+++ b/src/prin/defaults.py
@@ -61,6 +61,12 @@ DEFAULT_SUPPORTED_EXTENSIONS: list[str] = [
 DEFAULT_DOC_EXTENSIONS: list[str] = [".md", ".rst", ".mdx"]
 
 
+# When using default extensions (no custom -e provided), we also include
+# extensionless files like LICENSE, Makefile, Dockerfile by way of a sentinel
+# that the core engine recognizes.
+EXTENSIONLESS_SENTINEL: str = "<EXTENSIONLESS>"
+
+
 DEFAULT_TEST_EXCLUSIONS: list[TExclusion] = [
     "tests",
     "test",

--- a/src/prin/filters.py
+++ b/src/prin/filters.py
@@ -13,6 +13,7 @@ from .defaults import (
     DEFAULT_LOCK_EXCLUSIONS,
     DEFAULT_SUPPORTED_EXTENSIONS,
     DEFAULT_TEST_EXCLUSIONS,
+    EXTENSIONLESS_SENTINEL,
 )
 from .types import TExclusion, TExtension, TGlob, _is_extension, _is_glob
 
@@ -111,6 +112,8 @@ def resolve_extensions(
         extensions = DEFAULT_SUPPORTED_EXTENSIONS.copy()
         if not no_docs:
             extensions.extend(DEFAULT_DOC_EXTENSIONS)
+        # Include extensionless files by default
+        extensions.append(EXTENSIONLESS_SENTINEL)
 
     return extensions
 

--- a/tests/test_extensionless_files.py
+++ b/tests/test_extensionless_files.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from prin.core import StringWriter
+from prin.prin import main as prin_main
+
+
+def _write(p: Path, content: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+
+
+def _count_opening_xml_tags(text: str) -> int:
+    return sum(
+        1
+        for line in text.splitlines()
+        if line.startswith("<") and not line.startswith("</") and not line.endswith("/>")
+    )
+
+
+def test_extensionless_files_included_by_default(tmp_path: Path):
+    _write(tmp_path / "LICENSE", "All rights reserved\n")
+    _write(tmp_path / "Dockerfile", "FROM scratch\n")
+    _write(tmp_path / "a.py", "print(1)\n")
+
+    buf = StringWriter()
+    prin_main(argv=["--include-tests", str(tmp_path)], writer=buf)
+    out = buf.text()
+
+    assert "<LICENSE>" in out
+    assert "<Dockerfile>" in out
+    assert "<a.py>" in out
+
+
+def test_extensionless_respected_by_exclude_glob(tmp_path: Path):
+    _write(tmp_path / "LICENSE", "All rights reserved\n")
+    _write(tmp_path / "Dockerfile", "FROM scratch\n")
+    _write(tmp_path / "a.py", "print(1)\n")
+
+    buf = StringWriter()
+    prin_main(argv=["--include-tests", "-E", "LICENS*", str(tmp_path)], writer=buf)
+    out = buf.text()
+
+    assert "<LICENSE>" not in out
+    # Another extensionless file should still be included
+    assert "<Dockerfile>" in out
+    assert "<a.py>" in out
+


### PR DESCRIPTION
Print extensionless files by default unless explicitly excluded by a glob.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e0105ee-7cab-4bd6-858f-bf42c2bdef8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e0105ee-7cab-4bd6-858f-bf42c2bdef8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

