### PR TITLE
Analyze tests for conftest.py creation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,5 +4,23 @@
   - include/exclude tests flags: `-T/--include-tests`, `-K/--include-lock`, `-a/--text --include-binary --binary`, `-M/--include-empty`, `-l/--only-headers`, `--tag md|xml` (XML is covered indirectly; MD not explicitly).
   - parser wiring for `--exclude/--ignore` and `-e/--extension` is indirectly covered via helpers, but no end-to-end CLI invocation tests for `prin` script; coverage is via engine and helpers.
   - repo path extraction and traversal are covered; however, formatting options and include-empty/only-headers on repo path are not covered.
+
+# CLI coverage: features and tests
+
+Note: A feature counts as covered only when it is explicitly specified in the test (not just exercised via defaults). Either engine-level or `prin.main`-level tests are acceptable.
+
+- include-tests (`-T/--include-tests`): FS covered; Repo missing
+- include-lock (`-K/--include-lock`): FS missing; Repo missing
+- include-binary (`-a/--text/--include-binary/--binary`): FS missing; Repo missing
+- no-docs (`-d/--no-docs`): FS missing; Repo missing
+- include-empty (`-M/--include-empty`): FS missing; Repo missing
+- only-headers (`-l/--only-headers`): FS missing; Repo missing
+- extension (`-e/--extension`, repeatable): FS covered (engine sets explicitly); Repo missing
+- exclude (`-E/--exclude/--ignore`, repeatable): FS missing; Repo missing
+- no-exclude (`--no-exclude`): FS missing; Repo missing
+- no-ignore (`-I/--no-ignore`): FS missing; Repo missing
+- tag (`--tag xml|md`): FS missing; Repo covered (md)
+- max-files (`--max-files`): FS covered; Repo covered
+- positional roots (multiple inputs): FS covered; Repo covered
   - many planned options remain unimplemented; by definition they’re untested: hidden, no-ignore-vcs toggle, ignore-file, glob/force-glob, size, case-sensitive/ignore-case, unrestricted combos (`-u`/`-uu`/`-uuu`), follow symlinks, max-depth, absolute-paths, line-number.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _ensure_github_token():
+    if os.environ.get("GITHUB_TOKEN"):
+        return
+    token_path = Path.home() / ".github-token"
+    try:
+        token = token_path.read_text().strip()
+    except Exception:
+        token = ""
+    if token:
+        os.environ["GITHUB_TOKEN"] = token
+

--- a/tests/test_cli_engine_positional.py
+++ b/tests/test_cli_engine_positional.py
@@ -6,16 +6,10 @@ from prin.adapters.filesystem import FileSystemSource
 from prin.core import DepthFirstPrinter, StringWriter
 from prin.defaults import DEFAULT_BINARY_EXCLUSIONS, DEFAULT_EXCLUSIONS
 from prin.formatters import XmlFormatter
+from tests.utils import write_file, touch_file
 
 
-def _write(p: Path, content: str) -> None:
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(content, encoding="utf-8")
-
-
-def _touch(p: Path) -> None:
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.touch()
+ 
 
 
 def _run(src: FileSystemSource, roots: list[str]) -> str:
@@ -35,15 +29,15 @@ def _run(src: FileSystemSource, roots: list[str]) -> str:
 def test_explicit_single_ignored_file_is_printed(tmp_path: Path):
     # Create an ignored-by-default file (e.g., binary-like or lock)
     lock = tmp_path / "poetry.lock"
-    _write(lock, "dummy\n")
+    write_file(lock, "dummy\n")
     out = _run(FileSystemSource(root_cwd=tmp_path), [str(lock)])
     assert "<poetry.lock>" in out
 
 
 def test_two_sibling_directories(tmp_path: Path):
     # dirA and dirB siblings, each with printable files
-    _write(tmp_path / "dirA" / "a.py", "print('a')\n")
-    _write(tmp_path / "dirB" / "b.md", "# b\n")
+    write_file(tmp_path / "dirA" / "a.py", "print('a')\n")
+    write_file(tmp_path / "dirB" / "b.md", "# b\n")
     out = _run(
         FileSystemSource(root_cwd=tmp_path), [str(tmp_path / "dirA"), str(tmp_path / "dirB")]
     )
@@ -54,8 +48,8 @@ def test_two_sibling_directories(tmp_path: Path):
 
 def test_directory_and_explicit_ignored_file_inside(tmp_path: Path):
     # directory contains mixed files; specify dir and an otherwise-ignored file
-    _write(tmp_path / "work" / "keep.py", "print('ok')\n")
-    _touch(tmp_path / "work" / "__pycache__" / "junk.pyc")
+    write_file(tmp_path / "work" / "keep.py", "print('ok')\n")
+    touch_file(tmp_path / "work" / "__pycache__" / "junk.pyc")
     # Explicitly pass both the directory and the ignored file path
     out = _run(
         FileSystemSource(root_cwd=tmp_path),

--- a/tests/test_cli_engine_tmp_path.py
+++ b/tests/test_cli_engine_tmp_path.py
@@ -6,18 +6,10 @@ from prin.adapters.filesystem import FileSystemSource
 from prin.cli_common import Context, derive_filters_and_print_flags, parse_common_args
 from prin.core import DepthFirstPrinter, StringWriter
 from prin.formatters import XmlFormatter
+from tests.utils import write_file, touch_file
 
 
-def _write(p: Path, content: str) -> None:
-    """
-    Smell: this and similar functions across this tests/ dir should be moved to a shared tests/utils.py file.
-    """
-    p.write_text(content, encoding="utf-8")
-
-
-def _touch(p: Path) -> None:
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.touch()
+ 
 
 
 def test_cli_engine_happy_path(tmp_path):
@@ -26,21 +18,21 @@ def test_cli_engine_happy_path(tmp_path):
     (tmp_path / "docs").mkdir()
 
     # Included-by-default extensions: pick a subset (py, md, json*)
-    _write(tmp_path / "src" / "main.py", "print('hello')\nprint('world')\n")
-    _write(tmp_path / "docs" / "readme.md", "# Title\n\nSome docs.\n")
-    _write(tmp_path / "src" / "config.json", '{\n  "a": 1,\n  "b": 2\n}\n')
+    write_file(tmp_path / "src" / "main.py", "print('hello')\nprint('world')\n")
+    write_file(tmp_path / "docs" / "readme.md", "# Title\n\nSome docs.\n")
+    write_file(tmp_path / "src" / "config.json", '{\n  "a": 1,\n  "b": 2\n}\n')
 
     # Nested level
-    _write(tmp_path / "src" / "pkg" / "module.py", "def f():\n    return 1\n\nprint(f())\n")
-    _write(tmp_path / "src" / "pkg" / "data.jsonl", '{"x":1}\n{"x":2}\n')
+    write_file(tmp_path / "src" / "pkg" / "module.py", "def f():\n    return 1\n\nprint(f())\n")
+    write_file(tmp_path / "src" / "pkg" / "data.jsonl", '{"x":1}\n{"x":2}\n')
 
     # Default-ignored categories (lock/test/binary)
-    _write(tmp_path / "poetry.lock", "dummy\n")
-    _write(tmp_path / "package-lock.json", "{}\n")
-    _touch(tmp_path / "build" / "artifact.o")
-    _touch(tmp_path / "__pycache__" / "module.pyc")  # binary
+    write_file(tmp_path / "poetry.lock", "dummy\n")
+    write_file(tmp_path / "package-lock.json", "{}\n")
+    touch_file(tmp_path / "build" / "artifact.o")
+    touch_file(tmp_path / "__pycache__" / "module.pyc")  # binary
     (tmp_path / "tests").mkdir()
-    _write(tmp_path / "tests" / "test_something.py", "def test_x():\n    assert True\n")
+    write_file(tmp_path / "tests" / "test_something.py", "def test_x():\n    assert True\n")
 
     # Use hardcoded filters to isolate traversal/printing happy path
     src = FileSystemSource(root_cwd=tmp_path)
@@ -73,9 +65,9 @@ def test_cli_engine_happy_path(tmp_path):
 
 def test_cli_engine_isolation(tmp_path):
     (tmp_path / "dir" / "sub").mkdir(parents=True)
-    _write(tmp_path / "dir" / "a.py", "print('a')\nprint('b')\n")
-    _write(tmp_path / "dir" / "sub" / "b.md", "# b\n\ntext\n")
-    _touch(tmp_path / "__pycache__" / "c.pyc")
+    write_file(tmp_path / "dir" / "a.py", "print('a')\nprint('b')\n")
+    write_file(tmp_path / "dir" / "sub" / "b.md", "# b\n\ntext\n")
+    touch_file(tmp_path / "__pycache__" / "c.pyc")
 
     # Bypass parser-derived filters; hardcode simple includes/excludes
     src = FileSystemSource(root_cwd=tmp_path)

--- a/tests/test_max_files_fs.py
+++ b/tests/test_max_files_fs.py
@@ -4,45 +4,36 @@ from pathlib import Path
 
 from prin.core import StringWriter
 from prin.prin import main as prin_main
+from tests.utils import write_file, count_opening_xml_tags
 
 
-def _write(p: Path, content: str) -> None:
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(content, encoding="utf-8")
-
-
-def _count_opening_xml_tags(text: str) -> int:
-    return sum(
-        1
-        for line in text.splitlines()
-        if line.startswith("<") and not line.startswith("</") and not line.endswith("/>")
-    )
+ 
 
 
 def test_max_files_limits_printed_files_all_included(tmp_path: Path):
     # Build a small tree with 5 printable files
-    _write(tmp_path / "a.py", "print('a')\n")
-    _write(tmp_path / "b.py", "print('b')\n")
-    _write(tmp_path / "dir" / "c.py", "print('c')\n")
-    _write(tmp_path / "dir" / "d.py", "print('d')\n")
-    _write(tmp_path / "dir" / "sub" / "e.py", "print('e')\n")
+    write_file(tmp_path / "a.py", "print('a')\n")
+    write_file(tmp_path / "b.py", "print('b')\n")
+    write_file(tmp_path / "dir" / "c.py", "print('c')\n")
+    write_file(tmp_path / "dir" / "d.py", "print('d')\n")
+    write_file(tmp_path / "dir" / "sub" / "e.py", "print('e')\n")
 
     buf = StringWriter()
     prin_main(argv=["--include-tests", "--max-files", "4", str(tmp_path)], writer=buf)
     out = buf.text()
-    assert _count_opening_xml_tags(out) == 4
+    assert count_opening_xml_tags(out) == 4
 
 
 def test_max_files_skips_non_matching_and_still_prints_four(tmp_path: Path):
     # 4 printable files and one .lock that should not match by default extensions
-    _write(tmp_path / "a.lock", "dummy\n")  # ensure it sorts early among files
-    _write(tmp_path / "a.py", "print('a')\n")
-    _write(tmp_path / "dir" / "b.py", "print('b')\n")
-    _write(tmp_path / "dir" / "c.py", "print('c')\n")
-    _write(tmp_path / "dir" / "sub" / "d.py", "print('d')\n")
+    write_file(tmp_path / "a.lock", "dummy\n")  # ensure it sorts early among files
+    write_file(tmp_path / "a.py", "print('a')\n")
+    write_file(tmp_path / "dir" / "b.py", "print('b')\n")
+    write_file(tmp_path / "dir" / "c.py", "print('c')\n")
+    write_file(tmp_path / "dir" / "sub" / "d.py", "print('d')\n")
 
     buf = StringWriter()
     prin_main(argv=["--include-tests", "--max-files", "4", str(tmp_path)], writer=buf)
     out = buf.text()
-    assert _count_opening_xml_tags(out) == 4
+    assert count_opening_xml_tags(out) == 4
 

--- a/tests/test_max_files_repo.py
+++ b/tests/test_max_files_repo.py
@@ -1,30 +1,11 @@
 from __future__ import annotations
 
-import os
-from pathlib import Path
-
-import pytest
-
 from prin.core import StringWriter
 from prin.prin import main as prin_main
+from tests.utils import count_md_headers
 
 
-@pytest.fixture(autouse=True)
-def _ensure_github_token(monkeypatch):
-    # If not set, try to load from ~/.github-token to avoid rate limits
-    if os.environ.get("GITHUB_TOKEN"):
-        return
-    token_path = Path.home() / ".github-token"
-    try:
-        token = token_path.read_text().strip()
-    except Exception:
-        token = ""
-    if token:
-        monkeypatch.setenv("GITHUB_TOKEN", token)
-
-
-def _count_md_headers(text: str) -> int:
-    return sum(1 for line in text.splitlines() if line.startswith("# FILE: "))
+ 
 
 
 def test_repo_max_files_one():
@@ -32,5 +13,5 @@ def test_repo_max_files_one():
     buf = StringWriter()
     prin_main(argv=[url, "--max-files", "1", "--tag", "md"], writer=buf)
     out = buf.text()
-    assert _count_md_headers(out) == 1
+    assert count_md_headers(out) == 1
 

--- a/tests/test_print_mixed_fs_repo.py
+++ b/tests/test_print_mixed_fs_repo.py
@@ -1,22 +1,4 @@
-import os
-from pathlib import Path
-
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def _ensure_github_token(monkeypatch):
-    """Smell: This should be moved to tests/conftest.py to ensure it runs at the beginning of the test SESSION."""
-    # If not set, try to load from ~/.github-token to avoid rate limits
-    if os.environ.get("GITHUB_TOKEN"):
-        return
-    token_path = Path.home() / ".github-token"
-    try:
-        token = token_path.read_text().strip()
-    except Exception:
-        token = ""
-    if token:
-        monkeypatch.setenv("GITHUB_TOKEN", token)
+ 
 
 
 def test_mixed_fs_repo_interchangeably():

--- a/tests/test_print_repo_positional.py
+++ b/tests/test_print_repo_positional.py
@@ -1,27 +1,7 @@
 from __future__ import annotations
 
-import os
-from pathlib import Path
-
-import pytest
-
 from prin.core import StringWriter
 from prin.prin import main as prin_main
-
-
-@pytest.fixture(autouse=True)
-def _ensure_github_token(monkeypatch):
-    """Smell: This should be moved to tests/conftest.py to ensure it runs at the beginning of the test SESSION."""
-    # If not set, try to load from ~/.github-token to avoid rate limits
-    if os.environ.get("GITHUB_TOKEN"):
-        return
-    token_path = Path.home() / ".github-token"
-    try:
-        token = token_path.read_text().strip()
-    except Exception:
-        token = ""
-    if token:
-        monkeypatch.setenv("GITHUB_TOKEN", token)
 
 
 def test_repo_explicit_ignored_file_is_printed():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+
+def write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def touch_file(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+
+
+def count_opening_xml_tags(text: str) -> int:
+    return sum(
+        1
+        for line in text.splitlines()
+        if line.startswith("<") and not line.startswith("</") and not line.endswith("/>")
+    )
+
+
+def count_md_headers(text: str) -> int:
+    return sum(1 for line in text.splitlines() if line.startswith("# FILE: "))
+


### PR DESCRIPTION
Deduplicate test fixtures and helpers into `conftest.py` and `tests/utils.py` to improve test maintainability, and add a CLI feature test coverage summary to `TODO.md`.

---
<a href="https://cursor.com/background-agent?bcId=bc-fdea1ba9-d148-4de4-9928-624c8dcc1bef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fdea1ba9-d148-4de4-9928-624c8dcc1bef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

