### PR TITLE
Enhance fake file system fixture for tests

### DIFF
--- a/tests/test_options_fs.py
+++ b/tests/test_options_fs.py
@@ -14,7 +14,7 @@ def _run(argv: list[str]) -> str:
 
 
 def test_no_options_specified_everything_is_printed(fs_root):
-    out = _run(["--tag", "xml", str(fs_root)])
+    out = _run(["--tag", "xml", str(fs_root.root)])
 
     # Optional: show a quick sample while developing
     print(out.splitlines()[:20])
@@ -32,6 +32,11 @@ def test_no_options_specified_everything_is_printed(fs_root):
     for path in present:
         assert f"<{path}>" in out
         assert f"</{path}>" in out
+
+    # Utilize fixture contents mapping: at least one file's body matches
+    foo_text = fs_root.contents.get("foo.py", "").strip()
+    if foo_text:
+        assert foo_text in out
 
     # Absent by default (excluded by defaults)
     absent = [
@@ -61,37 +66,37 @@ def test_no_options_specified_everything_is_printed(fs_root):
 
 
 def test_include_tests_flag_includes_tests_dir(fs_root):
-    out = _run(["-T", str(fs_root)])
+    out = _run(["-T", str(fs_root.root)])
     assert "<tests/test_mod.py>" in out
 
 
 def test_include_lock_flag_includes_lock_files(fs_root):
-    out = _run(["--include-lock", str(fs_root)])
+    out = _run(["--include-lock", str(fs_root.root)])
     assert "<poetry.lock>" in out or "<package-lock.json>" in out or "<uv.lock>" in out
 
 
 def test_include_binary_includes_binary_like_files(fs_root):
-    out = _run(["--include-binary", str(fs_root)])
+    out = _run(["--include-binary", str(fs_root.root)])
     # image.png is matched by default binary exclusions; with include-binary it should appear
     assert "<image.png" in out
 
 
 def test_no_docs_excludes_markdown_and_rst(fs_root):
-    out = _run(["--no-docs", str(fs_root)])
+    out = _run(["--no-docs", str(fs_root.root)])
     assert "readme.md" not in out
     assert "README.md" not in out
     assert "notes.rst" not in out
 
 
 def test_include_empty_includes_truly_empty_and_semantically_empty(fs_root):
-    out = _run(["--include-empty", str(fs_root)])
+    out = _run(["--include-empty", str(fs_root.root)])
     assert "<empty.txt>" in out
     assert "<empty.py>" in out
     assert "<semantically_empty.py>" in out
 
 
 def test_only_headers_prints_headers_only(fs_root):
-    out = _run(["--include-tests", "--only-headers", str(fs_root)])
+    out = _run(["--include-tests", "--only-headers", str(fs_root.root)])
     # Expect no bodies, only paired headers; count a few known headers
     assert "</foo.py>" in out
     assert "</src/app.py>" in out
@@ -100,7 +105,7 @@ def test_only_headers_prints_headers_only(fs_root):
 
 
 def test_extension_filters_by_extension(fs_root):
-    out = _run(["-e", "py", str(fs_root)])
+    out = _run(["-e", "py", str(fs_root.root)])
     assert "<foo.py>" in out
     assert "<src/app.py>" in out
     assert "readme.md" not in out
@@ -108,7 +113,7 @@ def test_extension_filters_by_extension(fs_root):
 
 
 def test_exclude_glob_and_literal(fs_root):
-    out = _run(["--include-tests", "-E", "src", "-E", "*.md", str(fs_root)])
+    out = _run(["--include-tests", "-E", "src", "-E", "*.md", str(fs_root.root)])
     assert "<src/app.py>" not in out
     assert "<src/util.py>" not in out
     assert "readme.md" not in out
@@ -116,7 +121,7 @@ def test_exclude_glob_and_literal(fs_root):
 
 
 def test_no_exclude_disables_all_default_exclusions(fs_root):
-    out = _run(["--no-exclude", "--include-tests", str(fs_root)])
+    out = _run(["--no-exclude", "--include-tests", str(fs_root.root)])
     # cache/node_modules/build/vendor/logs/secrets should be allowed when no-exclude
     assert "<node_modules/pkg/index.js>" in out
     assert "<build/artifact.o>" in out
@@ -129,15 +134,15 @@ def test_no_exclude_disables_all_default_exclusions(fs_root):
 @pytest.mark.skip("Not supported ATM")
 def test_no_ignore_respects_gitignore_unless_disabled(fs_root):
     # By default, gitignored.txt should be excluded
-    out_default = _run([str(fs_root)])
+    out_default = _run([str(fs_root.root)])
     assert "gitignored.txt" not in out_default
 
     # With --no-ignore, gitignored.txt should be included
-    out_no_ignore = _run(["--no-ignore", str(fs_root)])
+    out_no_ignore = _run(["--no-ignore", str(fs_root.root)])
     assert "<gitignored.txt>" in out_no_ignore
 
 
 def test_tag_md_outputs_markdown_format(fs_root):
-    out = _run(["--include-tests", "--tag", "md", str(fs_root)])
+    out = _run(["--include-tests", "--tag", "md", str(fs_root.root)])
     assert count_md_headers(out) > 0
     assert "# FILE: foo.py" in out

--- a/tests/test_print_mixed_fs_repo.py
+++ b/tests/test_print_mixed_fs_repo.py
@@ -1,2 +1,14 @@
-def test_mixed_fs_repo_interchangeably():
-    """This test should pass a github URL and a mock file system root path positionally one after the other to the same main function, and assert that both are printed."""
+def test_mixed_fs_repo_interchangeably(fs_root):
+    """Ensure a GitHub URL and local fs root both print when passed together."""
+    from prin.core import StringWriter
+    from prin.prin import main as prin_main
+
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    buf = StringWriter()
+    prin_main(argv=[url, str(fs_root.root), "--max-files", "2"], writer=buf)
+    out = buf.text()
+    # One header from repo and one from local fs should appear at least
+    assert "# FILE: " in out or "<" in out
+    # Use fixture traversal paths to verify at least one known local path is present
+    any_local = any((f"<{p}>" in out or f"# FILE: {p}" in out) for p in fs_root.paths)
+    assert any_local


### PR DESCRIPTION
Enhance `fs_root` fixture to return a `NamedTuple` with file paths and contents, improving test assertion capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c3c205f-9b6c-4d4b-b7f1-3b0e73301c19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c3c205f-9b6c-4d4b-b7f1-3b0e73301c19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

