### PR TITLE
Find implemented TODO filesystem tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,22 +13,22 @@ Only `prin.main`-level tests are acceptable (Engine-level don't count).
   - [x] FS
   - [] Repo
 - include-lock (`-K/--include-lock`):
-  - [] FS
+  - [x] FS
   - [] Repo
 - include-binary (`-a/--text/--include-binary/--binary`):
-  - [] FS
+  - [x] FS
   - [] Repo
 - no-docs (`-d/--no-docs`):
   - [x] FS
   - [] Repo
 - include-empty (`-M/--include-empty`):
-  - [] FS
+  - [x] FS
   - [] Repo
 - only-headers (`-l/--only-headers`):
   - [x] FS
   - [] Repo
 - extension (`-e/--extension`, repeatable):
-  - [] FS
+  - [x] FS
   - [] Repo
 - exclude (`-E/--exclude/--ignore`, repeatable):
   - [x] FS


### PR DESCRIPTION
Mark `include-lock`, `include-binary`, `include-empty`, and `extension` filesystem tests as checked in `TODO.md` because they are already implemented in `test_options_fs.py`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e54a8a2e-8673-427a-a7e7-e23fc7992769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e54a8a2e-8673-427a-a7e7-e23fc7992769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

