### PR TITLE
Implement repo tests from markdown instructions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,32 +16,32 @@ Only `prin.main`-level tests are acceptable (Engine-level don't count).
   - [] FS
   - [] Repo
 - include-binary (`-a/--text/--include-binary/--binary`):
-  - [] FS
-  - [] Repo
+  - [x] FS
+  - [x] Repo
 - no-docs (`-d/--no-docs`):
   - [x] FS
-  - [] Repo
+  - [x] Repo
 - include-empty (`-M/--include-empty`):
   - [] FS
   - [] Repo
 - only-headers (`-l/--only-headers`):
   - [x] FS
-  - [] Repo
+  - [x] Repo
 - extension (`-e/--extension`, repeatable):
-  - [] FS
-  - [] Repo
+  - [x] FS
+  - [x] Repo
 - exclude (`-E/--exclude/--ignore`, repeatable):
   - [x] FS
-  - [] Repo
+  - [x] Repo
 - no-exclude (`--no-exclude`):
   - [x] FS
-  - [] Repo
+  - [x] Repo
 - no-ignore (`-I/--no-ignore`):
   - [] FS
   - [] Repo
 - tag (`--tag xml|md`):
   - [x] FS
-  - [] Repo
+  - [x] Repo
 - max-files (`--max-files`):
   - [x] FS
   - [x] Repo

--- a/TODO.md
+++ b/TODO.md
@@ -13,35 +13,35 @@ Only `prin.main`-level tests are acceptable (Engine-level don't count).
   - [x] FS
   - [] Repo
 - include-lock (`-K/--include-lock`):
-  - [] FS
+  - [x] FS
   - [] Repo
 - include-binary (`-a/--text/--include-binary/--binary`):
   - [x] FS
-  - [x] Repo
+  - [] Repo
 - no-docs (`-d/--no-docs`):
   - [x] FS
-  - [x] Repo
+  - [] Repo
 - include-empty (`-M/--include-empty`):
-  - [] FS
+  - [x] FS
   - [] Repo
 - only-headers (`-l/--only-headers`):
   - [x] FS
-  - [x] Repo
+  - [] Repo
 - extension (`-e/--extension`, repeatable):
   - [x] FS
-  - [x] Repo
+  - [] Repo
 - exclude (`-E/--exclude/--ignore`, repeatable):
   - [x] FS
-  - [x] Repo
+  - [] Repo
 - no-exclude (`--no-exclude`):
   - [x] FS
-  - [x] Repo
+  - [] Repo
 - no-ignore (`-I/--no-ignore`):
   - [] FS
   - [] Repo
 - tag (`--tag xml|md`):
   - [x] FS
-  - [x] Repo
+  - [] Repo
 - max-files (`--max-files`):
   - [x] FS
   - [x] Repo

--- a/tests/test_options_repo.py
+++ b/tests/test_options_repo.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from prin.core import StringWriter
+from tests.utils import count_md_headers
+import pytest
+from prin.prin import main as prin_main
+
+
+def _run(argv: list[str]) -> str:
+    buf = StringWriter()
+    prin_main(argv=argv, writer=buf)
+    return buf.text()
+
+
+def test_repo_defaults_readme_present_binaries_excluded():
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    out = _run(["--tag", "xml", url])
+
+    # Defaults should include README.md
+    assert "<README.md>" in out
+
+    # Defaults should exclude binary-like files (e.g., PNGs)
+    assert "<logos/made_for_typingmind.png>" not in out
+    assert "<logos/made_for_typingmind_transparent.png>" not in out
+
+
+def test_repo_include_binary_includes_pngs():
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    out = _run(["--include-binary", url])
+    # Binary files are emitted as self-closing tags in XML format
+    assert "<logos/made_for_typingmind.png" in out or "<logos/made_for_typingmind_transparent.png" in out
+
+
+def test_repo_no_docs_excludes_markdown_and_rst():
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    out = _run(["--no-docs", url])
+    assert "README.md" not in out
+
+
+def test_repo_only_headers_prints_headers_only():
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    out = _run(["--only-headers", url])
+    assert "</README.md>" in out
+    assert "Awesome TypingMind" not in out
+
+
+def test_repo_extension_filters():
+    rust_repo = "https://github.com/trouchet/rust-hello"
+    out_rs = _run(["-e", "rs", rust_repo])
+    assert "<src/main.rs>" in out_rs
+    assert "<Cargo.toml>" not in out_rs
+    assert "<README.md>" not in out_rs
+
+    tm_repo = "https://github.com/TypingMind/awesome-typingmind"
+    out_md = _run(["-e", "md", tm_repo])
+    assert "<README.md>" in out_md
+    assert "<logos/made_for_typingmind.png" not in out_md
+
+
+def test_repo_exclude_glob_and_literal():
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    out = _run(["-E", "logos", "-E", "*.md", url])
+    assert "<logos/README.md>" not in out
+    assert "<README.md>" not in out
+
+
+def test_repo_no_exclude_disables_all_default_exclusions():
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    out = _run(["--no-exclude", url])
+    assert "<logos/made_for_typingmind.png" in out or "<logos/made_for_typingmind_transparent.png" in out
+
+
+def test_repo_tag_md_outputs_markdown_format():
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    out = _run(["--tag", "md", url])
+    assert count_md_headers(out) > 0
+    assert "# FILE: README.md" in out
+
+
+@pytest.mark.skip("Not supported ATM")
+def test_repo_include_empty():
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    out = _run(["--include-empty", url])
+    # No specific assertion; placeholder to mirror FS coverage
+    assert isinstance(out, str)
+
+
+@pytest.mark.skip("Not supported ATM")
+def test_repo_include_lock():
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    out = _run(["--include-lock", url])
+    assert isinstance(out, str)
+
+
+@pytest.mark.skip("Not supported ATM")
+def test_repo_no_ignore():
+    url = "https://github.com/TypingMind/awesome-typingmind"
+    out = _run(["--no-ignore", url])
+    assert isinstance(out, str)
+
+


### PR DESCRIPTION
Add repo-equivalent tests for various `prin` options to ensure consistent behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b9a5018-9afa-48cf-8325-87836a9ce797">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b9a5018-9afa-48cf-8325-87836a9ce797">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

