### PR TITLE
Ignore comments in python file empty check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,8 @@ def fs_root(tmp_path_factory: pytest.TempPathFactory) -> VFS:
 
     # Empty and semantically empty
     touch_file(root / "empty.txt")  # truly empty
-    touch_file(root / "empty.py")  # truly empty .py
+    # empty.py should be treated as semantically empty even with a comment
+    write_file(root / "empty.py", "# empty python file with only a comment\n")
     write_file(
         root / "semantically_empty.py",
         '"""Module docstring"""\nimport os\nfrom sys import version as _v\n__all__ = ["x"]\n',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,11 +47,10 @@ def fs_root(tmp_path_factory: pytest.TempPathFactory) -> VFS:
 
     # Empty and semantically empty
     touch_file(root / "empty.txt")  # truly empty
-    # empty.py should be treated as semantically empty even with a comment
-    write_file(root / "empty.py", "# empty python file with only a comment\n")
+    touch_file(root / "empty.py")  # truly empty .py
     write_file(
         root / "semantically_empty.py",
-        '"""Module docstring"""\nimport os\nfrom sys import version as _v\n__all__ = ["x"]\n',
+        '"""Module docstring"""\n# a comment line\nimport os\nfrom sys import version as _v\n__all__ = ["x"]\n',
     )
 
     # Binary-like and cache/hidden

--- a/tests/test_options_repo.py
+++ b/tests/test_options_repo.py
@@ -77,12 +77,12 @@ def test_repo_tag_md_outputs_markdown_format():
     assert "# FILE: README.md" in out
 
 
-@pytest.mark.skip("Not supported ATM")
 def test_repo_include_empty():
-    url = "https://github.com/TypingMind/awesome-typingmind"
+    # Use a repo that has a file with only a comment and an import
+    # The file "__init__.py.py" contains a comment and an import, which should be semantically empty
+    url = "https://github.com/mahin-mushfique/scrapers"
     out = _run(["--include-empty", url])
-    # No specific assertion; placeholder to mirror FS coverage
-    assert isinstance(out, str)
+    assert "<__init__.py.py>" in out
 
 
 @pytest.mark.skip("Not supported ATM")


### PR DESCRIPTION
Update Python `is_empty` check to ignore comments, treating files with only comments as semantically empty.

---
<a href="https://cursor.com/background-agent?bcId=bc-62e199a5-2060-4689-a86b-799d1302bd27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-62e199a5-2060-4689-a86b-799d1302bd27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

