### PR TITLE
Unskip test for repo with Cargo.lock

### DIFF
--- a/tests/test_options_repo.py
+++ b/tests/test_options_repo.py
@@ -85,11 +85,10 @@ def test_repo_include_empty():
     assert "<__init__.py.py>" in out
 
 
-@pytest.mark.skip("Not supported ATM")
 def test_repo_include_lock():
-    url = "https://github.com/TypingMind/awesome-typingmind"
+    url = "https://github.com/trouchet/rust-hello"
     out = _run(["--include-lock", url])
-    assert isinstance(out, str)
+    assert "<Cargo.lock>" in out
 
 
 @pytest.mark.skip("Not supported ATM")


### PR DESCRIPTION
Unskip `test_repo_include_lock` and point it to a repository with `Cargo.lock` at its root.

---
<a href="https://cursor.com/background-agent?bcId=bc-4219b53b-ba05-4309-aac6-6c1b89f7bb85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4219b53b-ba05-4309-aac6-6c1b89f7bb85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

