### PR TITLE
Alias argument expansion for cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Force case-insensitive matching of the search pattern. By default, case sensitiv
 
 - `-H`, `--hidden` (listed above for clarity) — planned ⏳
 
-- `-u`, `--unrestricted` — planned ⏳
+- `-u`, `--unrestricted` — implemented ✅
 Unrestricted search: include hidden files and disable ignore rules (equivalent to --hidden --no-ignore).
 
 - `-uu` — planned ⏳


### PR DESCRIPTION
Implement `-u`/`--unrestricted` CLI alias, expanding to `--hidden --no-ignore` before argparse to simplify usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec3f326d-8152-4149-8630-b9e171261e82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ec3f326d-8152-4149-8630-b9e171261e82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

