### PR TITLE
Refine default constant categories

### DIFF
--- a/src/prin/defaults.py
+++ b/src/prin/defaults.py
@@ -12,6 +12,13 @@ from prin.types import TExclusion
 
 HiddenFiles = lambda x: x.startswith(".")
 
+DEFAULT_SECRET_EXCLUSIONS: list[TExclusion] = [
+    # Environment and secrets
+    "secrets",
+    "*.key",
+    "*.pem",
+]
+
 DEFAULT_EXCLUSIONS: list[TExclusion] = [
     lambda x: x.endswith("egg-info"),
     "build",
@@ -28,20 +35,11 @@ DEFAULT_EXCLUSIONS: list[TExclusion] = [
     # IDE and editor files
     "*.swp",
     "*.swo",
-    # Language-specific
-    "*.class",
-    "*.o",
-    "*.so",
-    "*.dylib",
     # Logs and temporary files
     "logs",
     "*.log",
     "*.tmp",
-    # Environment and secrets
-    "secrets",
-    "*.key",
-    "*.pem",
-]
+] + DEFAULT_SECRET_EXCLUSIONS
 
 
 DEFAULT_SUPPORTED_EXTENSIONS: list[str] = [
@@ -96,6 +94,10 @@ DEFAULT_BINARY_EXCLUSIONS: list[TExclusion] = [
     "*.pyc",
     "*.pyo",
     "*.pyd",
+    "*.class",
+    "*.o",
+    "*.so",
+    "*.dylib",
     "*.exe",
     "*.dll",
     "*.app",

--- a/src/prin/filters.py
+++ b/src/prin/filters.py
@@ -22,16 +22,15 @@ from .path_classifier import _is_glob
 def is_glob(path) -> TypeIs[TGlob]:
     """Return True if the string should be treated as a glob pattern.
 
-    Special-case: plain extension tokens (e.g., ".py" or "py") are NOT globs.
-    This allows extension filters and extension-based exclusions to behave
-    intuitively (endswith semantics) instead of fnmatch against a literal.
+    Rules:
+    - If there are no wildcard characters (*, ?, [) present, treat as NOT a glob.
+    - Always treat plain extension tokens (".py" or "py") as NOT globs.
+    - Otherwise, fall back to regex-style classification.
     """
     if isinstance(path, str):
-        # Treat both ".ext" and "ext" as extension tokens (not globs)
-        no_wildcards = not any(ch in path for ch in "*?[]")
-        no_sep = ("/" not in path) and ("\\" not in path)
-        is_plain_token = path.strip(".").isalnum()
-        if (_is_extension(path)) or (no_wildcards and no_sep and is_plain_token):
+        if _is_extension(path):
+            return False
+        if not any(ch in path for ch in "*?[]"):
             return False
     return _is_glob(path)
 

--- a/src/prin/filters.py
+++ b/src/prin/filters.py
@@ -20,6 +20,19 @@ from .path_classifier import _is_glob
 
 @typechecked
 def is_glob(path) -> TypeIs[TGlob]:
+    """Return True if the string should be treated as a glob pattern.
+
+    Special-case: plain extension tokens (e.g., ".py" or "py") are NOT globs.
+    This allows extension filters and extension-based exclusions to behave
+    intuitively (endswith semantics) instead of fnmatch against a literal.
+    """
+    if isinstance(path, str):
+        # Treat both ".ext" and "ext" as extension tokens (not globs)
+        no_wildcards = not any(ch in path for ch in "*?[]")
+        no_sep = ("/" not in path) and ("\\" not in path)
+        is_plain_token = path.strip(".").isalnum()
+        if (_is_extension(path)) or (no_wildcards and no_sep and is_plain_token):
+            return False
     return _is_glob(path)
 
 


### PR DESCRIPTION
Reorganize `DEFAULT_*` constants for semantic orthogonality and refine glob detection.

Binary file globs and secrets were moved to dedicated lists (`DEFAULT_BINARY_EXCLUSIONS`, `DEFAULT_SECRET_EXCLUSIONS`) to improve clarity and maintainability. Additionally, the `is_glob` function was refined to correctly handle plain extensions and non-wildcard paths, ensuring exclusion rules function as intended after the refactor.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8773a73-8c83-4148-9f45-99c0e3b51262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8773a73-8c83-4148-9f45-99c0e3b51262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

