### PR TITLE
Fix path handling in file system source

### DIFF
--- a/src/prin/core.py
+++ b/src/prin/core.py
@@ -219,12 +219,15 @@ class DepthFirstPrinter:
         if not self.extensions:
             return True
         for pattern in self.extensions:
-            if self._is_glob(pattern):
+            # Treat patterns with wildcard metacharacters as globs; otherwise as extensions
+            has_wildcards = any(ch in pattern for ch in ("*", "?", "["))
+            if has_wildcards:
                 from fnmatch import fnmatch
 
                 if fnmatch(filename, pattern):
                     return True
             else:
+                # Support both "py" and ".py" notations
                 if filename.endswith("." + pattern.removeprefix(".")):
                     return True
         return False


### PR DESCRIPTION
Correct `DepthFirstPrinter`'s extension matching to distinguish between literal extensions and glob patterns, fixing the `test_two_sibling_directories` failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-68799f71-7381-46f6-87a3-45c384ca2980">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68799f71-7381-46f6-87a3-45c384ca2980">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

