### PR TITLE
Register and use network pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,3 +109,8 @@ indent-style = "space"
 line-ending = "auto"
 quote-style = "double"
 skip-magic-trailing-comma = false
+
+[tool.pytest.ini_options]
+markers = [
+  "network: tests that require network access",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,3 +184,26 @@ def fs_root() -> VFS:
         )
     finally:
         shutil.rmtree(root, ignore_errors=True)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--no-network",
+        action="store_true",
+        default=False,
+        help="Skip tests that require network access (marked with @pytest.mark.network)",
+    )
+
+
+def pytest_configure(config):
+    # Redundant with pyproject markers, but safe if running in isolation
+    config.addinivalue_line("markers", "network: tests that require network access")
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption("--no-network"):
+        return
+    skip_network = pytest.mark.skip(reason="network disabled via --no-network")
+    for item in items:
+        if "network" in item.keywords:
+            item.add_marker(skip_network)

--- a/tests/test_max_files_repo.py
+++ b/tests/test_max_files_repo.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from prin.core import StringWriter
+import pytest
 from prin.prin import main as prin_main
 from tests.utils import count_md_headers
 
 
+@pytest.mark.network
 def test_repo_max_files_one():
     url = "https://github.com/TypingMind/awesome-typingmind"
     buf = StringWriter()

--- a/tests/test_options_repo.py
+++ b/tests/test_options_repo.py
@@ -13,6 +13,7 @@ def _run(argv: list[str]) -> str:
     return buf.text()
 
 
+@pytest.mark.network
 def test_repo_defaults_readme_present_binaries_excluded():
     url = "https://github.com/TypingMind/awesome-typingmind"
     out = _run(["--tag", "xml", url])
@@ -25,6 +26,7 @@ def test_repo_defaults_readme_present_binaries_excluded():
     assert "<logos/made_for_typingmind_transparent.png>" not in out
 
 
+@pytest.mark.network
 def test_repo_include_binary_includes_pngs():
     url = "https://github.com/TypingMind/awesome-typingmind"
     out = _run(["--include-binary", url])
@@ -35,12 +37,14 @@ def test_repo_include_binary_includes_pngs():
     )
 
 
+@pytest.mark.network
 def test_repo_no_docs_excludes_markdown_and_rst():
     url = "https://github.com/TypingMind/awesome-typingmind"
     out = _run(["--no-docs", url])
     assert "README.md" not in out
 
 
+@pytest.mark.network
 def test_repo_only_headers_prints_headers_only():
     url = "https://github.com/TypingMind/awesome-typingmind"
     out = _run(["--only-headers", url])
@@ -48,6 +52,7 @@ def test_repo_only_headers_prints_headers_only():
     assert "Awesome TypingMind" not in out
 
 
+@pytest.mark.network
 def test_repo_extension_filters():
     rust_repo = "https://github.com/trouchet/rust-hello"
     out_rs = _run(["-e", "rs", rust_repo])
@@ -61,6 +66,7 @@ def test_repo_extension_filters():
     assert "<logos/made_for_typingmind.png" not in out_md
 
 
+@pytest.mark.network
 def test_repo_exclude_glob_and_literal():
     url = "https://github.com/TypingMind/awesome-typingmind"
     out = _run(["-E", "logos", "-E", "*.md", url])
@@ -68,6 +74,7 @@ def test_repo_exclude_glob_and_literal():
     assert "<README.md>" not in out
 
 
+@pytest.mark.network
 def test_repo_no_exclude_disables_all_default_exclusions():
     url = "https://github.com/TypingMind/awesome-typingmind"
     out = _run(["--no-exclude", url])
@@ -77,6 +84,7 @@ def test_repo_no_exclude_disables_all_default_exclusions():
     )
 
 
+@pytest.mark.network
 def test_repo_tag_md_outputs_markdown_format():
     url = "https://github.com/TypingMind/awesome-typingmind"
     out = _run(["--tag", "md", url])
@@ -84,6 +92,7 @@ def test_repo_tag_md_outputs_markdown_format():
     assert "# FILE: README.md" in out
 
 
+@pytest.mark.network
 def test_repo_include_empty():
     # Use a repo that has a file with only a comment and an import
     # The file "__init__.py.py" contains a comment and an import, which should be semantically empty
@@ -92,6 +101,7 @@ def test_repo_include_empty():
     assert "<__init__.py.py>" in out
 
 
+@pytest.mark.network
 def test_repo_include_lock():
     url = "https://github.com/trouchet/rust-hello"
     out = _run(["--include-lock", url])

--- a/tests/test_print_mixed_fs_repo.py
+++ b/tests/test_print_mixed_fs_repo.py
@@ -1,3 +1,7 @@
+import pytest
+
+
+@pytest.mark.network
 def test_mixed_fs_repo_interchangeably(fs_root):
     """Ensure a GitHub URL and local fs root both print when passed together."""
     from prin.core import StringWriter

--- a/tests/test_print_repo_positional.py
+++ b/tests/test_print_repo_positional.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from prin.core import StringWriter
+import pytest
 from prin.prin import main as prin_main
 
 
+@pytest.mark.network
 def test_repo_explicit_ignored_file_is_printed():
     # LICENSE has no extension; treat it as ignored by default, but explicit path must print it
     url = "https://github.com/TypingMind/awesome-typingmind/LICENSE"
@@ -13,6 +15,7 @@ def test_repo_explicit_ignored_file_is_printed():
     assert "<LICENSE>" in out
 
 
+@pytest.mark.network
 def test_pass_two_repositories_positionally_print_both():
     url1 = "https://github.com/TypingMind/awesome-typingmind"
     url2 = "https://github.com/trouchet/rust-hello"
@@ -24,6 +27,7 @@ def test_pass_two_repositories_positionally_print_both():
     assert "<Cargo.toml>" in out
 
 
+@pytest.mark.network
 def test_repo_dir_and_explicit_ignored_file():
     # Embed LICENSE in URL, and also traverse repo root by adding an empty root
     url = "https://github.com/TypingMind/awesome-typingmind/LICENSE"

--- a/tests/test_website_adapter.py
+++ b/tests/test_website_adapter.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from prin.core import StringWriter
+import pytest
 from prin.prin import main as prin_main
 
 
+@pytest.mark.network
 def test_website_llms_txt_presence_and_one_file_md_output():
     base = "https://www.fastht.ml/docs"
     buf = StringWriter()


### PR DESCRIPTION
Register `pytest.mark.network` and add a `--no-network` CLI option to skip network-dependent tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-140b0966-5265-4749-9ce4-1e6375680c67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-140b0966-5265-4749-9ce4-1e6375680c67">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

