### PR TITLE
Fix repo only-headers test output

### DIFF
--- a/tests/test_options_repo.py
+++ b/tests/test_options_repo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+import re
 
 from prin.core import StringWriter
 from prin.prin import main as prin_main
@@ -48,7 +49,13 @@ def test_repo_no_docs_excludes_markdown_and_rst():
 def test_repo_only_headers_prints_headers_only():
     url = "https://github.com/TypingMind/awesome-typingmind"
     out = _run(["--only-headers", url])
-    assert "</README.md>" in out
+    # Expect plaintext list of file paths, one per line
+    assert re.search(r"^README\.md$", out, re.MULTILINE)
+    assert re.search(r"^LICENSE$", out, re.MULTILINE)
+    assert re.search(r"^logos/README\.md$", out, re.MULTILINE)
+    # Ensure XML tags and bodies are not present
+    assert "<README.md>" not in out
+    assert "</README.md>" not in out
     assert "Awesome TypingMind" not in out
 
 


### PR DESCRIPTION
Update `test_repo_only_headers_prints_headers_only` to assert plaintext file paths, as `--only-headers` should not output XML tags.

The test previously expected XML-style paired tags, but the correct behavior for `--only-headers` is to print a simple, plaintext list of file paths, one per line. This change aligns the test with the actual and intended output, mirroring the expectations of the `fs` option tests.

---
<a href="https://cursor.com/background-agent?bcId=bc-39bb259a-8c3d-4a2e-93c4-8a104e7347bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-39bb259a-8c3d-4a2e-93c4-8a104e7347bc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

