### PR TITLE
Implement pytest coverage with README badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,11 +31,50 @@ jobs:
       - name: Run coverage
         run: ./cov.sh
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage.xml
-          fail_ci_if_error: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Extract coverage percentage
+        id: coverage
+        run: |
+          COVERAGE=$(uv run coverage report | grep TOTAL | awk '{print $6}' | sed 's/%//')
+          echo "percentage=$COVERAGE" >> $GITHUB_OUTPUT
+          echo "Coverage: $COVERAGE%"
+          
+          # Determine badge color based on coverage
+          if (( COVERAGE >= 90 )); then
+            COLOR="brightgreen"
+          elif (( COVERAGE >= 80 )); then
+            COLOR="green"  
+          elif (( COVERAGE >= 70 )); then
+            COLOR="yellow"
+          elif (( COVERAGE >= 60 )); then
+            COLOR="orange"
+          else
+            COLOR="red"
+          fi
+          echo "color=$COLOR" >> $GITHUB_OUTPUT
+
+      - name: Update coverage badge in README
+        if: github.ref == 'refs/heads/master'
+        run: |
+          COVERAGE="${{ steps.coverage.outputs.percentage }}"
+          COLOR="${{ steps.coverage.outputs.color }}"
+          BADGE_URL="https://img.shields.io/badge/coverage-${COVERAGE}%25-${COLOR}"
+          
+          # Replace the codecov badge with our coverage badge
+          sed -i "s|https://codecov.io/gh/giladbarnea/prin/branch/master/graph/badge.svg|${BADGE_URL}|g" README.md
+          sed -i "s|https://codecov.io/gh/giladbarnea/prin|#|g" README.md
+          
+          echo "Updated README.md with coverage: ${COVERAGE}% (${COLOR})"
+
+      - name: Commit updated README
+        if: github.ref == 'refs/heads/master'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add README.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update coverage badge to ${{ steps.coverage.outputs.percentage }}%"
+            git push
+          fi
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build](https://github.com/giladbarnea/prin/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/giladbarnea/prin/actions/workflows/build.yml)
 [![tests](https://github.com/giladbarnea/prin/actions/workflows/tests.yml/badge.svg?branch=master)](https://github.com/giladbarnea/prin/actions/workflows/tests.yml)
 [![coverage](https://github.com/giladbarnea/prin/actions/workflows/coverage.yml/badge.svg?branch=master)](https://github.com/giladbarnea/prin/actions/workflows/coverage.yml)
-[![codecov](https://codecov.io/gh/giladbarnea/prin/branch/master/graph/badge.svg)](https://codecov.io/gh/giladbarnea/prin)
+[![coverage](https://img.shields.io/badge/coverage-56%25-red)](#)
 
 Print the contents of full directories, remote GitHub repositories and websites in an LLM-friendly format for increased prompt performance.
 


### PR DESCRIPTION
Replace Codecov integration with a self-contained pytest coverage badge to avoid third-party service dependencies and provide a free, automatic coverage display.

---
<a href="https://cursor.com/background-agent?bcId=bc-710c3f65-1258-4622-b9bd-e9e194f30c70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-710c3f65-1258-4622-b9bd-e9e194f30c70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

