### PR TITLE
Debug external directory exclusion in tests

### DIFF
--- a/src/prin/filters.py
+++ b/src/prin/filters.py
@@ -84,6 +84,10 @@ def is_excluded(entry: Any, *, exclude: list[TExclusion]) -> bool:
         needed = len(token_parts)
         if needed == 0:
             continue
+        # Special-case simple tokens with no separators: also match file/directory name or stem equal to token
+        if needed == 1:
+            if name == token or stem == token:
+                return True
         # Slide a window over path_parts and compare joined POSIX strings
         for i in range(0, len(path_parts) - needed + 1):
             if path_parts[i : i + needed] == token_parts:

--- a/tests/test_options_fs.py
+++ b/tests/test_options_fs.py
@@ -102,6 +102,17 @@ def test_extension_filters_by_extension(fs_root: VFS):
     assert "data.json" not in out
 
 
+def test_module_named_locking_is_not_excluded(fs_root: VFS):
+    # Create a module under src/locking to ensure 'lock' substring does not cause exclusion
+    from tests.utils import write_file
+
+    mod_path = fs_root.root / "src" / "locking" / "main.py"
+    write_file(mod_path, "print('locking module ok')\n")
+
+    out = _run([str(fs_root.root)])
+    assert "<src/locking/main.py>" in out
+
+
 def test_exclude_glob_and_literal(fs_root: VFS):
     out = _run(["--include-tests", "--exclude", "src", "--exclude", "*.md", str(fs_root.root)])
     for test_file in fs_root.test_files:

--- a/tests/test_options_fs.py
+++ b/tests/test_options_fs.py
@@ -113,6 +113,28 @@ def test_module_named_locking_is_not_excluded(fs_root: VFS):
     assert "<src/locking/main.py>" in out
 
 
+def test_literal_exclude_token_matches_segments_not_substrings(fs_root: VFS):
+    from tests.utils import write_file
+
+    # Create files that should be excluded by literal token 'pizza'
+    write_file(fs_root.root / "src" / "pizza" / "main.py", "print('pizza dir')\n")
+    write_file(fs_root.root / "src" / "pizza.py", "print('pizza file')\n")
+
+    # Create files that should NOT be excluded (substring only)
+    write_file(fs_root.root / "src" / "nicepizzas" / "main.py", "print('nicepizzas dir')\n")
+    write_file(fs_root.root / "src" / "nicepizzas.py", "print('nicepizzas file')\n")
+
+    out = _run(["--exclude", "pizza", str(fs_root.root)])
+
+    # Excluded
+    assert "<src/pizza/main.py>" not in out
+    assert "<src/pizza.py>" not in out
+
+    # Not excluded
+    assert "<src/nicepizzas/main.py>" in out
+    assert "<src/nicepizzas.py>" in out
+
+
 def test_exclude_glob_and_literal(fs_root: VFS):
     out = _run(["--include-tests", "--exclude", "src", "--exclude", "*.md", str(fs_root.root)])
     for test_file in fs_root.test_files:


### PR DESCRIPTION
Refine plain-text exclusion logic to match exact path segments, preventing unintended substring exclusions.

Previously, plain-text exclusions (e.g., 'out') would match as substrings within path components (e.g., 'outside_source'). This led to a bug where a valid directory was incorrectly excluded. The updated logic ensures that such exclusions only apply when an exact path segment matches the exclusion token.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5d19840-b126-4c25-9c01-de7bde5745c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5d19840-b126-4c25-9c01-de7bde5745c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

