### PR TITLE
Add commit-specific GitHub repo support

### DIFF
--- a/PARITIES.md
+++ b/PARITIES.md
@@ -231,7 +231,7 @@ See "Maintaining `PARITIES.md`" section at the bottom of this file for detailed 
 #### Members
 - `src/prin/prin.py`: routing of input tokens across filesystem, GitHub, and website; repo subpath extraction; global `FileBudget` use.
 - `src/prin/util.py`: `is_github_url`, `is_http_url`
-- `src/prin/adapters/github.py`: `parse_github_url` → `owner`, `repo`, `subpath`
+- `src/prin/adapters/github.py`: `parse_github_url` → `owner`, `repo`, `subpath`, `ref`
 
 #### Contract
 - Routing logic and helper predicates must align:

--- a/src/prin/adapters/github.py
+++ b/src/prin/adapters/github.py
@@ -28,12 +28,12 @@ def _auth_headers() -> Dict[str, str]:
     return headers
 
 
-class GitHubURL(TypedDict, total=False):
+class GitHubURL(TypedDict):
     owner: str
     repo: str
     subpath: str
-    # Optional git ref (branch, tag, or commit SHA) if present in the URL
-    ref: str
+    # Git ref (branch, tag, or commit SHA). Always present; may be None if not specified in URL.
+    ref: Optional[str]
 
 
 def parse_github_url(url: str) -> GitHubURL:
@@ -94,9 +94,8 @@ def parse_github_url(url: str) -> GitHubURL:
         "owner": owner,
         "repo": repo,
         "subpath": "/".join(subpath_parts),
+        "ref": ref,
     }
-    if ref:
-        data["ref"] = ref
     return data
 
 
@@ -203,7 +202,7 @@ class GitHubRepoSource(SourceAdapter):
         parsed_github_url: GitHubURL = parse_github_url(url)
         owner, repo = parsed_github_url["owner"], parsed_github_url["repo"]
         # Prefer explicit ref from URL (commit sha, tag, branch). Fallback to default branch.
-        ref = parsed_github_url.get("ref") or self._fetch_default_branch(owner, repo)
+        ref = parsed_github_url["ref"] or self._fetch_default_branch(owner, repo)
         self._ctx = _Ctx(owner=owner, repo=repo, ref=ref)
 
     @functools.lru_cache

--- a/src/prin/adapters/github.py
+++ b/src/prin/adapters/github.py
@@ -10,6 +10,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, Iterable, Optional, TypedDict
+from urllib.parse import parse_qs, urlparse
 
 import requests
 
@@ -49,16 +50,41 @@ def parse_github_url(url: str) -> GitHubURL:
 
     Raises ValueError if the URL is not a valid GitHub URL.
     """
+    u = url.strip()
+    # Determine host/path robustly across http(s), scheme-less, and ssh forms
+    host: str
+    path: str
+    query_params: dict[str, list[str]] = {}
+    if u.startswith("git@github.com:"):
+        host = "github.com"
+        path = u.split(":", 1)[1]
+    else:
+        # Ensure urlparse sees a scheme when missing
+        tmp = u
+        if not (u.startswith("http://") or u.startswith("https://")):
+            if u.startswith("www.") or u.startswith("github.com/") or u.startswith("api.github.com/") or u.startswith("raw.githubusercontent.com/"):
+                tmp = "https://" + u
+        parsed = urlparse(tmp)
+        query_params = parse_qs(parsed.query)
+        if parsed.netloc:
+            host = parsed.netloc.lower()
+            path = parsed.path
+        else:
+            # Fallback: scheme-less host/path
+            parts = u.split("/", 1)
+            host = (parts[0] if parts else "github.com").lower()
+            path = "/" + (parts[1] if len(parts) > 1 else "")
+
+    raw_base = f"{host}{('/' + path.lstrip('/')) if not path.startswith('/') else path}"
     raw = (
-        url.strip()
-        .removeprefix("git+")
-        .removeprefix("http://")
-        .removeprefix("https://")
+        raw_base
         .removeprefix("www.")
         .removeprefix("api.")
         .removeprefix("github.com/")
+        .removeprefix("raw.githubusercontent.com/")
         .removeprefix("repos/")
         .removesuffix("/")
+        .removesuffix(".git")
     )
 
     # Split into path segments once normalized
@@ -86,6 +112,23 @@ def parse_github_url(url: str) -> GitHubURL:
         # owner/repo/blob/<ref>/file/or/path
         ref = rest[1]
         subpath_parts = rest[2:]
+    elif host == "api.github.com" and rest[:1] == ["contents"]:
+        # api.github.com/repos/<owner>/<repo>/contents(/path)? with optional ?ref=
+        subpath_parts = rest[1:]
+        ref = (query_params.get("ref") or [None])[0]
+    elif host == "api.github.com" and rest[:2] == ["git", "trees"] and len(rest) >= 3:
+        # api.github.com/repos/<owner>/<repo>/git/trees/<ref>
+        ref = rest[2]
+        subpath_parts = []
+    elif host == "raw.githubusercontent.com" and len(rest) >= 1:
+        # raw.githubusercontent.com/<owner>/<repo>/<ref>/<path>
+        if len(rest) >= 1:
+            # For raw, the parts already start after repo; rebuild using parsed host path
+            # Re-parse: owner/repo handled earlier, so rest is [<ref>, path...]
+            # Since we normalized host+path, parts are owner, repo, <ref>, path...
+            # Adjust because earlier split used raw starting after host, so here rest includes ref and subpath
+            ref = rest[0] if rest else None
+            subpath_parts = rest[1:]
     else:
         # Treat everything after repo as a subpath. No explicit ref.
         subpath_parts = rest

--- a/src/prin/util.py
+++ b/src/prin/util.py
@@ -7,7 +7,9 @@ from prin.adapters import github
 
 def is_github_url(token: str) -> bool:
     try:
-        return "github.com" in token and github.parse_github_url(token)
+        # Accept common GitHub hosts/forms, including raw and ssh
+        hostish = ("github.com" in token) or ("raw.githubusercontent.com" in token) or token.startswith("git@github.com:")
+        return bool(hostish and github.parse_github_url(token))
     except ValueError:
         return False
 

--- a/tests/test_github_adapter.py
+++ b/tests/test_github_adapter.py
@@ -31,3 +31,77 @@ def test_parse_owner_repo(url):
     repo = parsed_github_url["repo"]
     assert owner == "TypingMind"
     assert repo == "awesome-typingmind"
+
+
+@pytest.mark.parametrize(
+    "url, exp_ref, exp_subpath",
+    [
+        # tree at ref (root and with subpath)
+        (
+            "https://github.com/TypingMind/awesome-typingmind/tree/d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "",
+        ),
+        (
+            "https://github.com/TypingMind/awesome-typingmind/tree/d4ce90b21bc6c04642ebcf448f96357a8b474624/logos",
+            "d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "logos",
+        ),
+        # blob at ref (with query and fragment)
+        (
+            "https://github.com/TypingMind/awesome-typingmind/blob/d4ce90b21bc6c04642ebcf448f96357a8b474624/README.md?plain=1#L1-L10",
+            "d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "README.md",
+        ),
+        # commit with short SHA (parsing only)
+        (
+            "https://github.com/TypingMind/awesome-typingmind/commit/d4ce90b",
+            "d4ce90b",
+            "",
+        ),
+        # API contents with ref query param
+        (
+            "https://api.github.com/repos/TypingMind/awesome-typingmind/contents/README.md?ref=d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "README.md",
+        ),
+        # API contents at root with ref
+        (
+            "https://api.github.com/repos/TypingMind/awesome-typingmind/contents?ref=d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "",
+        ),
+        # API git trees with ref
+        (
+            "https://api.github.com/repos/TypingMind/awesome-typingmind/git/trees/d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "",
+        ),
+        # Raw content URL
+        (
+            "https://raw.githubusercontent.com/TypingMind/awesome-typingmind/d4ce90b21bc6c04642ebcf448f96357a8b474624/README.md",
+            "d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "README.md",
+        ),
+        # Strip trailing slash and .git
+        (
+            "https://github.com/TypingMind/awesome-typingmind.git/",
+            None,
+            "",
+        ),
+        # SSH/clone form
+        (
+            "git@github.com:TypingMind/awesome-typingmind.git",
+            None,
+            "",
+        ),
+    ],
+)
+def test_parse_ref_and_subpath(url, exp_ref, exp_subpath):
+    parsed: GitHubURL = parse_github_url(url)
+    assert parsed["owner"] == "TypingMind"
+    assert parsed["repo"] == "awesome-typingmind"
+    # ref key should always exist (may be None)
+    assert "ref" in parsed
+    assert parsed["ref"] == exp_ref
+    assert parsed["subpath"] == exp_subpath

--- a/tests/test_github_adapter.py
+++ b/tests/test_github_adapter.py
@@ -53,6 +53,18 @@ def test_parse_owner_repo(url):
             "d4ce90b21bc6c04642ebcf448f96357a8b474624",
             "README.md",
         ),
+        # blob at ref with fragment-only line range (strip #Lstart-Lend)
+        (
+            "https://github.com/TypingMind/awesome-typingmind/blob/d4ce90b21bc6c04642ebcf448f96357a8b474624/README.md#L5-L20",
+            "d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "README.md",
+        ),
+        # blob at ref with single-line fragment (strip #Lnum)
+        (
+            "https://github.com/TypingMind/awesome-typingmind/blob/d4ce90b21bc6c04642ebcf448f96357a8b474624/README.md#L12",
+            "d4ce90b21bc6c04642ebcf448f96357a8b474624",
+            "README.md",
+        ),
         # commit with short SHA (parsing only)
         (
             "https://github.com/TypingMind/awesome-typingmind/commit/d4ce90b",

--- a/tests/test_options_repo.py
+++ b/tests/test_options_repo.py
@@ -63,6 +63,19 @@ def test_repo_only_headers_prints_headers_only():
 
 
 @pytest.mark.network
+def test_repo_commit_only_headers_two_files():
+    # Specific commit should reflect point-in-time state
+    url = (
+        "https://github.com/TypingMind/awesome-typingmind/commit/"
+        "d4ce90b21bc6c04642ebcf448f96357a8b474624"
+    )
+    out = _run(["--only-headers", url])
+    # Expect exactly two files listed
+    lines = [ln.strip() for ln in out.splitlines() if ln.strip()]
+    assert set(lines) == {"LICENSE", "README.md"}
+
+
+@pytest.mark.network
 def test_repo_extension_filters():
     rust_repo = "https://github.com/trouchet/rust-hello"
     out_rs = _run(["-e", "rs", rust_repo])

--- a/tests/test_options_repo.py
+++ b/tests/test_options_repo.py
@@ -76,6 +76,39 @@ def test_repo_commit_only_headers_two_files():
 
 
 @pytest.mark.network
+def test_repo_commit_readme_contents_matches():
+    # Specific commit and README.md contents should match expected text (ignoring whitespace diffs)
+    url = (
+        "https://github.com/TypingMind/awesome-typingmind/blob/"
+        "d4ce90b21bc6c04642ebcf448f96357a8b474624/README.md"
+    )
+
+    expected_readme_contents = """
+# awesome-typingmind
+Collection of useful resources
+for TypingMind
+"""
+
+    # Use XML to easily isolate the body between <README.md> tags
+    out = _run(["--tag", "xml", url])
+
+    start_tag = "<README.md>"
+    end_tag = "</README.md>"
+    start = out.find(start_tag)
+    assert start >= 0, "README.md header not found in output"
+    start_body = start + len(start_tag)
+    end = out.find(end_tag, start_body)
+    assert end > start_body, "README.md closing tag not found in output"
+    body = out[start_body:end]
+
+    def _normalize(s: str) -> str:
+        # Collapse all whitespace (spaces, tabs, newlines) to single spaces and trim
+        return " ".join(s.split()).strip()
+
+    assert _normalize(body) == _normalize(expected_readme_contents)
+
+
+@pytest.mark.network
 def test_repo_extension_filters():
     rust_repo = "https://github.com/trouchet/rust-hello"
     out_rs = _run(["-e", "rs", rust_repo])

--- a/tests/test_print_repo_positional.py
+++ b/tests/test_print_repo_positional.py
@@ -39,3 +39,28 @@ def test_repo_dir_and_explicit_ignored_file():
     out = buf.text()
     assert "<README.md>" not in out  # normal traversal doesn't print repo files
     assert "<LICENSE>" in out  # explicit inclusion prints extensionless file
+
+
+@pytest.mark.network
+def test_repo_raw_and_api_and_ssh_forms_all_work_headers_only():
+    from prin.core import StringWriter
+    from prin.prin import main as prin_main
+
+    # raw.githubusercontent.com at specific ref
+    raw_url = (
+        "https://raw.githubusercontent.com/TypingMind/awesome-typingmind/"
+        "d4ce90b21bc6c04642ebcf448f96357a8b474624/README.md"
+    )
+    # API contents with ref
+    api_contents_url = (
+        "https://api.github.com/repos/TypingMind/awesome-typingmind/contents/README.md"
+        "?ref=d4ce90b21bc6c04642ebcf448f96357a8b474624"
+    )
+    # SSH repo root (no ref)
+    ssh_url = "git@github.com:TypingMind/awesome-typingmind.git"
+
+    buf = StringWriter()
+    prin_main(argv=["--only-headers", raw_url, api_contents_url, ssh_url], writer=buf)
+    out = buf.text()
+    # raw/api should produce exactly README.md entries; ssh root should include LICENSE or README.md
+    assert "README.md" in out


### PR DESCRIPTION
Enable specifying a GitHub repository at a specific commit, branch, or tag via its URL to retrieve files from that point in time.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5751cd2-949b-45dc-b431-560f9b18fa69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5751cd2-949b-45dc-b431-560f9b18fa69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

