### PR TITLE
Update config and docs with new flags

### DIFF
--- a/PARITIES.md
+++ b/PARITIES.md
@@ -260,6 +260,25 @@ See "Maintaining `PARITIES.md`" section at the bottom of this file for detailed 
 #### Tests
 - Covered indirectly via options and mixed-source tests; add story-based tests if examples grow in complexity.
 
+## Set 17 [TEST-ADAPTER-MARKERS-FLAGS]: Pytest markers/flags ↔ source adapters
+
+#### Members
+- `tests/conftest.py`: `pytest_addoption` (`--website`, `--repo`, `--no-website`, `--no-repo`) and `pytest_collection_modifyitems` selection logic.
+- `pyproject.toml` `[tool.pytest.ini_options].markers`: `website`, `repo`.
+- Website tests: `tests/test_website_adapter.py`, `tests/test_website_adapter_all_urls.py` (use `pytest.mark.website`).
+- Repo tests: `tests/test_options_repo.py`, `tests/test_print_repo_positional.py`, `tests/test_max_files_repo.py`, `tests/test_github_adapter.py` (use `pytest.mark.repo`).
+- Source adapters: `src/prin/adapters/website.py`, `src/prin/adapters/github.py`, `src/prin/adapters/filesystem.py`.
+
+#### Contract
+- Pytest markers/flags must map 1:1 to source adapter kinds: `website` → Website adapter; `repo` → GitHub adapter; filesystem is unmarked default.
+- Include flags (`--website`/`--repo`) restrict to marked suites; exclude flags (`--no-website`/`--no-repo`) skip them; README documents these options.
+
+#### Triggers
+- Adding/renaming an adapter or a marker/flag; changing test selection semantics.
+
+#### Tests
+- Suite-level marks present and honored by `tests/conftest.py`; running `./test.sh --website` executes only website-marked tests; `./test.sh --no-repo` skips repo-marked tests.
+
 ## Set 15 [EXPLICIT-PATH-FORCE-INCLUDE]: Explicit files bypass exclusions
 #### Members
 - `src/prin/core.py`: DFS handling of `NotADirectoryError` → force include; duplicate suppression.

--- a/PARITIES.md
+++ b/PARITIES.md
@@ -206,12 +206,19 @@ See "Maintaining `PARITIES.md`" section at the bottom of this file for detailed 
 - `tests/test_cli_engine_*.py`: traversal and path display behavior.
 - `tests/test_max_files_*.py`: `--max-files` semantics.
 - `tests/test_website_adapter_*.py`: website parsing and rendering.
+ - `tests/conftest.py`: adapter-specific pytest markers and selection flags (`--website`, `--repo`, `--no-website`, `--no-repo`).
+ - `pyproject.toml` `[tool.pytest.ini_options].markers`: `website`, `repo` declarations.
 
 #### Contract
 - For each implemented feature/flag, maintain parallel coverage for filesystem and GitHub (and website where applicable). Adding a feature implies adding/adapting tests in all relevant suites.
+ - Adapter markers/flags must map 1:1 to source adapters; include flags restrict to marked suites; exclude flags skip them.
 
 #### Triggers
 - Adding a new option/behavior; adding a new adapter.
+
+#### Tests
+- FS: `tests/test_options_fs.py` (for example flags); Repo: `tests/test_options_repo.py`; Website: `tests/test_website_adapter_*.py`.
+- Marker selection honored: `./test.sh --website` runs only website-marked tests; `./test.sh --no-repo` skips repo-marked tests.
 
 ## Set 12 [WEBSITE-LLMS-TXT-PARSING]: URL list parsing ↔ rendering
 #### Members
@@ -259,25 +266,6 @@ See "Maintaining `PARITIES.md`" section at the bottom of this file for detailed 
 
 #### Tests
 - Covered indirectly via options and mixed-source tests; add story-based tests if examples grow in complexity.
-
-## Set 17 [TEST-ADAPTER-MARKERS-FLAGS]: Pytest markers/flags ↔ source adapters
-
-#### Members
-- `tests/conftest.py`: `pytest_addoption` (`--website`, `--repo`, `--no-website`, `--no-repo`) and `pytest_collection_modifyitems` selection logic.
-- `pyproject.toml` `[tool.pytest.ini_options].markers`: `website`, `repo`.
-- Website tests: `tests/test_website_adapter.py`, `tests/test_website_adapter_all_urls.py` (use `pytest.mark.website`).
-- Repo tests: `tests/test_options_repo.py`, `tests/test_print_repo_positional.py`, `tests/test_max_files_repo.py`, `tests/test_github_adapter.py` (use `pytest.mark.repo`).
-- Source adapters: `src/prin/adapters/website.py`, `src/prin/adapters/github.py`, `src/prin/adapters/filesystem.py`.
-
-#### Contract
-- Pytest markers/flags must map 1:1 to source adapter kinds: `website` → Website adapter; `repo` → GitHub adapter; filesystem is unmarked default.
-- Include flags (`--website`/`--repo`) restrict to marked suites; exclude flags (`--no-website`/`--no-repo`) skip them; README documents these options.
-
-#### Triggers
-- Adding/renaming an adapter or a marker/flag; changing test selection semantics.
-
-#### Tests
-- Suite-level marks present and honored by `tests/conftest.py`; running `./test.sh --website` executes only website-marked tests; `./test.sh --no-repo` skips repo-marked tests.
 
 ## Set 15 [EXPLICIT-PATH-FORCE-INCLUDE]: Explicit files bypass exclusions
 #### Members

--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ In both cases, the `prin` executable should be available in your shell.
 - Lint and format: `./lint.sh` and `./format.sh`.
  - To add or remove a dependency, use `uv add` or `uv remove`.
 
+##### Testing adapter-specific suites
+
+You can focus or skip tests for specific adapters via pytest flags:
+
+```sh
+# Run only website adapter tests
+./test.sh --website
+
+# Run only GitHub repo adapter tests
+./test.sh --repo
+
+# Skip website adapter tests
+./test.sh --no-website
+
+# Skip GitHub repo adapter tests
+./test.sh --no-repo
+
+# Combine with network control
+./test.sh --website --no-network
+```
+
 #### Task Completion Checklist (create internal todo list)
 
 1. **Prep** (before any code)


### PR DESCRIPTION
Add `--no-website` and `--no-repo` pytest flags to allow skipping specific adapter tests, and update the documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-058a1fd4-0f73-4e17-b9d9-52057abbe509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-058a1fd4-0f73-4e17-b9d9-52057abbe509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

