### PR TITLE
Adjust parities-check logging levels

### DIFF
--- a/tests/test_parities_check.py
+++ b/tests/test_parities_check.py
@@ -344,5 +344,5 @@ def test_merge_opportunity_id_parts_only(id_a, id_b, should_warn, capsys):
     from internal.parities_check import rule_merge_opportunities
 
     msgs = rule_merge_opportunities(parsed)
-    warn = any(m.severity == "WARN" and m.rule == "MergeOpportunity" for m in msgs)
-    assert warn is should_warn
+    suggest = any(m.severity == "SUGGESTION" and m.rule == "MergeOpportunity" for m in msgs)
+    assert suggest is should_warn


### PR DESCRIPTION
Downgrade `parities-check` severities from `ERROR` to `WARNING` and `WARNING` to `SUGGESTION`, adjusting the script's exit behavior to fail only on `WARNING`.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bd19019-fd1d-488a-bf2e-3640bec7f5a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7bd19019-fd1d-488a-bf2e-3640bec7f5a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

