### PR TITLE
Run branch cleanup workflow locally with act

### DIFF
--- a/tmp_simulate_github_script.js
+++ b/tmp_simulate_github_script.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+
+const OUTPUT = fs.existsSync('out.txt') ? fs.readFileSync('out.txt', 'utf8') : '';
+const context = { repo: { owner: 'giladbarnea', repo: 'prin' } };
+
+const github = {
+  search: {
+    issuesAndPullRequests: async ({ q }) => {
+      return { data: { total_count: 1, items: [] } };
+    },
+  },
+  issues: {
+    update: async ({ owner, repo, issue_number, body }) => ({ data: {} }),
+    create: async ({ owner, repo, title, body }) => ({ data: {} }),
+  },
+};
+
+(async () => {
+  const title = 'Automated: Branch cleanup candidates (dry-run)';
+  const body = `Weekly dry-run found candidate branches.\n\nOutput:\n\n\`\`\`\n${OUTPUT}\n\`\`\`\n\nComment: '@Cursor run script with -s --execute then close this issue' to execute deletion including stale branches.`;
+  const { data } = await github.search.issuesAndPullRequests({
+    q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title}"`
+  });
+  if (data.total_count > 0) {
+    const issue = data.items[0];
+    await github.issues.update({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, body });
+  } else {
+    await github.issues.create({ owner: context.repo.owner, repo: context.repo.repo, title, body });
+  }
+})();
+
+ 


### PR DESCRIPTION
Add local simulation files to reproduce a TypeError in the `branch-cleanup-dryrun` workflow's `github-script` step.

The workflow's `github-script` step implicitly assumes `data.items[0]` exists if `data.total_count > 0`. This simulation demonstrates that if `total_count` is positive but `items` is an empty array, accessing `data.items[0]` yields `undefined`, causing a `TypeError` when subsequently trying to access `issue.number`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc8064e0-d7fd-49d2-a070-cab3b093e2fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc8064e0-d7fd-49d2-a070-cab3b093e2fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

