### PR TITLE
Test and refine file detection with -l

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,20 @@
 #!/usr/bin/env bash
-uv tool run --refresh . -- "$@"
+
+main() {
+  source .common.sh
+  ensure_uv
+  if [[ -t 1 && -t 0 &&
+    "$USER" = giladbarnea &&
+    "$LOGNAME" = giladbarnea &&
+    "$__CFBundleIdentifier" != com.jetbrains.pycharm &&
+    -z "$CURSOR_AGENT" &&
+    "$TERM_PROGRAM" != vscode &&
+    "$VSCODE_INJECTION" != 1 &&
+    -z "$CURSOR_TRACE_ID" ]]; then
+    uv run python -m prin.prin "$@"
+  else
+    uv run python -m prin.prin "$@" 2>&1 | decolor
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Refactor `run.sh` to mirror `test.sh`'s structure for reliable `uv` and `prin` execution.

The original `run.sh` directly called `uv` without ensuring it was in the PATH or installed, leading to "command not found" errors. This change adopts the `test.sh` pattern, correctly sourcing `.common.sh` and calling `ensure_uv`, making `run.sh` robust and self-sufficient.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0f2254b-5f33-4dab-bcff-630d21d6bfeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0f2254b-5f33-4dab-bcff-630d21d6bfeb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

