### PR TITLE
Implement fd ignore file parsing

### DIFF
--- a/PARITIES.md
+++ b/PARITIES.md
@@ -237,17 +237,20 @@ See "Maintaining `PARITIES.md`" section at the bottom of this file for detailed 
 #### Triggers
 - Changing explicit-path routing or how adapters signal file vs directory.
 
-## Set 16 [GITIGNORE-BEHAVIOR]: Current `.gitignore` semantics
+## Set 16 [GITIGNORE-BEHAVIOR]: `.gitignore` semantics
 
 #### Members
-- `src/prin/filters.py`: `get_gitignore_exclusions` (currently returns `[]`).
-- `src/prin/cli_common.py`: `Context.__post_init__` composition of exclusions with `no_ignore`.
+- `src/prin/adapters/filesystem.py`: `FileSystemSource.configure` initializes `GitIgnoreEngine`; `should_print` consults engine first.
+- `src/prin/filters.py`: `GitIgnoreEngine` implementation; `get_gitignore_exclusions` shim.
+- `src/prin/cli_common.py`: `Context.__post_init__` keeps `no_ignore` field; help text.
+- `SPEC.md`: CLI option notes for `--no-ignore`.
+- `README.md`: Sane defaults list includes VCS ignore paths.
 
 #### Contract
-- Until real `.gitignore` parsing is implemented, gitignored files are not excluded by default. Flags (`--no-ignore`, `-u`, `-uu`) remain consistent with current stubbed behavior and README/alias documentation.
+- By default, filesystem traversal respects `.gitignore`, `.git/info/exclude`, global `~/.config/git/ignore`, plus `.ignore` and `.fdignore`. The last matching rule wins, and negations are honored. `--no-ignore` disables this engine. Explicit file roots still force-include.
 
 #### Triggers
-- Implementing real `.gitignore` parsing; changing the meaning of `no_ignore`/`unrestricted`.
+- Changing ignore engine semantics or sources; altering `--no-ignore` meaning.
 
 ## Set 17 [PATTERN-THEN-PATH]: Pattern-then-path interface
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ prin "*.rs" github.com/rust-lang/book
 3. Binary files
 4. Dot-files and dot-dirs (.env, .git, .cache, .vscode, etc.)
 5. Tests
-6. Git-ignored paths  // noqa: parities
+6. Git-ignored paths (.gitignore, .git/info/exclude, ~/.config/git/ignore, plus .ignore and .fdignore)  // noqa: parities
 
 Each can be included in the output by specifying its corresponding `--include-...` CLI flag.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -102,6 +102,6 @@ $ prin main /home/foo
 - `-K`, `--include-lock`: include lock files.
 - `-M`, `--include-empty`: include empty files (and semantically-empty Python files).
 - `-a`, `--binary`, `--include-binary` (alias: `--text`): include binary files.
-- `-I`, `--no-ignore` (aliases: `--no-gitignore`, `-u`, `--unrestricted`): do not honor VCS ignore files (currently no-op; `.gitignore` parsing not implemented).
+- `-I`, `--no-ignore` (aliases: `--no-gitignore`, `-u`, `--unrestricted`): do not honor VCS ignore files (.gitignore, .git/info/exclude, ~/.config/git/ignore, plus .ignore and .fdignore are ignored by default unless this is set).
 - `--no-exclude`, `-uuu`, `--include-all`: include everything (disable all default exclusions).
 - `-uu`: shorthand for `--hidden --no-ignore`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
+    "pathspec>=0.12,<1",
     "requests>=2.32.5",
 ]
 

--- a/src/prin/adapters/filesystem.py
+++ b/src/prin/adapters/filesystem.py
@@ -317,12 +317,9 @@ class FileSystemSource(SourceAdapter):
         self.extensions = ctx.extensions
         self.include_empty = ctx.include_empty
         # Initialize ignore engine unless --no-ignore or --no-exclude
-        try:
-            if not ctx.no_exclude and not ctx.no_ignore:
-                self._ignore_engine = GitIgnoreEngine(self.anchor)
-            else:
-                self._ignore_engine = None
-        except Exception:
+        if not ctx.no_exclude and not ctx.no_ignore:
+            self._ignore_engine = GitIgnoreEngine(self.anchor)
+        else:
             self._ignore_engine = None
 
     def should_print(self, entry: Entry) -> bool:
@@ -349,13 +346,9 @@ class FileSystemSource(SourceAdapter):
         dummy = Entry(path=PurePosixPath(target), name=entry.name, kind=entry.kind)
         # Apply gitignore engine first (fd behavior: VCS ignores by default, overridable)
         if self._ignore_engine is not None:
-            try:
-                abs_path = Path(str(entry.abs_path or entry.path))
-                if self._ignore_engine.is_ignored(abs_path):
-                    return False
-            except Exception:
-                # On any error, fall back to other filters only
-                pass
+            abs_path = Path(str(entry.abs_path or entry.path))
+            if self._ignore_engine.is_ignored(abs_path):
+                return False
         if is_excluded(dummy, exclude=self.exclusions):
             return False
         if not extension_match(dummy, extensions=self.extensions):

--- a/src/prin/filters.py
+++ b/src/prin/filters.py
@@ -6,6 +6,9 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Sequence
 
+from pathspec.gitignore import GitIgnoreSpec
+from pathspec.util import normalize_file
+
 from .path_classifier import classify_pattern, is_glob
 from .types import Pattern
 
@@ -28,27 +31,132 @@ def read_gitignore_file(gitignore_path: Path) -> list[Pattern]:
 
 
 def get_gitignore_exclusions(paths: list[str]) -> list[Pattern]:
-    """Get exclusions from gitignore files for given paths."""
+    """
+    Backward-compat shim for callers that expect a list of exclusions from VCS ignore files.
 
-    # Note: .gitignore is parked for now until we figure out how to exclude in development time.
+    Now returns an empty list and VCS ignore handling is performed by a dedicated engine
+    integrated at the adapter layer. Kept to preserve the call site in Context.__post_init__.
+    """
     return []
-    exclusions = []
 
-    # Read global git ignore file
-    home_config_ignore = Path.home() / ".config" / "git" / "ignore"
-    exclusions.extend(read_gitignore_file(home_config_ignore))
 
-    # Read gitignore files for each directory path
-    for path_str in paths:
-        p = Path(path_str)
-        if p.is_dir():
-            gitignore_path = p / ".gitignore"
-            exclusions.extend(read_gitignore_file(gitignore_path))
+class GitIgnoreEngine:
+    """
+    Git-ignore style matcher that aggregates patterns from:
+    - ~/.config/git/ignore (global)
+    - Per-directory: .fdignore, .ignore, .gitignore
+    - Repo-specific: .git/info/exclude (if present under the root)
 
-            git_exclude_path = p / ".git" / "info" / "exclude"
-            exclusions.extend(read_gitignore_file(git_exclude_path))
+    Semantics:
+    - Patterns are interpreted using Git's wildmatch rules (via pathspec)
+    - Deeper directories override ancestor patterns (last match wins)
+    - Negations ("!") are honored
+    - Matching is done against paths relative to the configured root
+    """
 
-    return exclusions
+    def __init__(self, root: Path) -> None:
+        self.root = Path(root).resolve()
+        self._dir_spec_cache: dict[Path, GitIgnoreSpec] = {}
+        self._global_spec: GitIgnoreSpec | None = self._load_global_spec()
+
+    def _load_global_spec(self) -> GitIgnoreSpec | None:
+        lines: list[str] = []
+        try:
+            global_path = Path.home() / ".config" / "git" / "ignore"
+            if global_path.exists():
+                lines.extend(global_path.read_text(encoding="utf-8").splitlines())
+        except Exception:
+            pass
+        if not lines:
+            return None
+        return GitIgnoreSpec.from_lines(lines)
+
+    @staticmethod
+    def _prefixed_lines(lines: list[str], prefix: str) -> list[str]:
+        """
+        Prefix every non-comment, non-empty pattern line with the directory prefix so
+        that patterns are evaluated relative to the engine root while keeping the
+        per-file scoping semantics.
+        """
+        if prefix and not prefix.endswith("/"):
+            prefix = prefix + "/"
+        out: list[str] = []
+        for raw in lines:
+            line = raw.rstrip("\n")
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            negate = stripped.startswith("!")
+            body = stripped[1:] if negate else stripped
+            if body.startswith("/"):
+                body = body[1:]
+            # Scope to directory
+            scoped = f"{prefix}{body}" if prefix else body
+            out.append(("!" + scoped) if negate else scoped)
+        return out
+
+    def _load_dir_spec(self, directory: Path) -> GitIgnoreSpec:
+        # Compose spec from ancestor directory specs + current directory ignores
+        if directory in self._dir_spec_cache:
+            return self._dir_spec_cache[directory]
+
+        parent = directory.parent
+        spec_lines: list[str] = []
+        if directory != self.root:
+            parent_spec = self._load_dir_spec(parent)
+            # Start from parent's compiled patterns
+            base_patterns = list(parent_spec.patterns)  # type: ignore[attr-defined]
+            spec = GitIgnoreSpec(base_patterns)
+        else:
+            # Root starts from global spec if any
+            spec = self._global_spec or GitIgnoreSpec.from_lines([])
+
+        # Aggregate current directory ignore files
+        try:
+            rel_dir = directory.relative_to(self.root).as_posix()
+        except Exception:
+            rel_dir = ""
+
+        def read_lines(p: Path) -> list[str]:
+            try:
+                return p.read_text(encoding="utf-8").splitlines()
+            except Exception:
+                return []
+
+        lines_here: list[str] = []
+        lines_here += self._prefixed_lines(read_lines(directory / ".fdignore"), rel_dir)
+        lines_here += self._prefixed_lines(read_lines(directory / ".ignore"), rel_dir)
+        lines_here += self._prefixed_lines(read_lines(directory / ".gitignore"), rel_dir)
+        # Repo-specific excludes (usually only under repo root)
+        lines_here += self._prefixed_lines(read_lines(directory / ".git" / "info" / "exclude"), rel_dir)
+
+        if lines_here:
+            spec += GitIgnoreSpec.from_lines(lines_here)
+
+        self._dir_spec_cache[directory] = spec
+        return spec
+
+    def is_ignored(self, abs_path: Path) -> bool:
+        """Return True if abs_path should be ignored according to aggregated patterns."""
+        file_path = Path(abs_path)
+        try:
+            rel = file_path.relative_to(self.root).as_posix()
+        except Exception:
+            # If outside the root, do not ignore
+            rel = normalize_file(str(file_path))
+        dir_path = file_path.parent if file_path.is_absolute() else (self.root / file_path).parent
+        # Clamp the directory to root subtree
+        try:
+            while True:
+                dir_path.relative_to(self.root)
+                break
+        except Exception:
+            dir_path = self.root
+
+        spec = self._load_dir_spec(dir_path)
+        res = spec.check_file(rel)
+        # res.include is True → include, False → exclude, None → no match
+        return bool(res.include is False)
 
 
 def is_excluded(entry: "Entry", *, exclude: Sequence[Pattern]) -> bool:
@@ -56,6 +164,20 @@ def is_excluded(entry: "Entry", *, exclude: Sequence[Pattern]) -> bool:
     # Match against full POSIX path only (relative to traversal base)
     target = path.as_posix()
     for _exclude in exclude:
+        # Support GitIgnoreSpec-style matchers stored in the list
+        try:
+            from pathspec.gitignore import GitIgnoreSpec as _GIS  # Local import for optional dep
+        except Exception:
+            _GIS = None  # type: ignore[assignment]
+
+        if _GIS is not None and isinstance(_exclude, _GIS):  # type: ignore[arg-type]
+            # We don't have the root context here, so prefer using adapter engine.
+            # If present in the list, treat a match (include=False) as exclusion.
+            res = _exclude.check_file(target)
+            if res.include is False:
+                return True
+            # If include True or None, fall through to other patterns
+            continue
         kind: Literal["regex", "glob"] = classify_pattern(_exclude)
         if kind == "glob":
             if fnmatch(target, t.cast(str, _exclude).strip()):

--- a/uv.lock
+++ b/uv.lock
@@ -267,6 +267,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -301,6 +310,7 @@ name = "prin"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "pathspec" },
     { name = "requests" },
 ]
 
@@ -318,7 +328,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32.5" }]
+requires-dist = [
+    { name = "pathspec", specifier = ">=0.12,<1" },
+    { name = "requests", specifier = ">=2.32.5" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Implement fd-style ignore handling to respect VCS ignore files by default.

This PR introduces a `GitIgnoreEngine` that parses `.gitignore`, `.ignore`, `.fdignore`, `.git/info/exclude`, and global `~/.config/git/ignore` files, applying their rules during filesystem traversal. This aligns `prin`'s default behavior with `fd` by automatically excluding ignored paths unless `--no-ignore` is specified.

---
<a href="https://cursor.com/background-agent?bcId=bc-dec41ea7-5793-4300-a1f6-6c84e738c28a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dec41ea7-5793-4300-a1f6-6c84e738c28a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

