### PR TITLE
Review codebase for missing parities

### DIFF
--- a/PARITIES.md
+++ b/PARITIES.md
@@ -166,6 +166,7 @@ See "Maintaining `PARITIES.md`" section at the bottom of this file for detailed 
 #### Members
 - `src/prin/core.py`: `FileBudget`.
 - `src/prin/prin.py`: single `FileBudget` instance shared across all sources.
+- `src/prin/cli_common.py`: `Context.max_files`.
 
 #### Contract
 - The budget is enforced globally across all sources during a single invocation. New sources must share the same budget.
@@ -271,6 +272,19 @@ See "Maintaining `PARITIES.md`" section at the bottom of this file for detailed 
 - Changing pattern matching semantics; modifying path display logic.
 
  
+## Set 18 [FS-DISPLAY-WHAT-THEN-WHERE]: Filesystem display semantics
+
+#### Members
+- `SPEC.md`: What–Then–Where: Filesystem Path Display Spec
+- `src/prin/adapters/filesystem.py`: `walk_pattern`
+- `src/prin/adapters/filesystem.py`: `_display_rel`
+- `README.md`: “Basic Usage”/“Matching” examples showing displayed path shapes
+
+#### Contract
+- The search_path token’s shape solely dictates displayed path form: None/child → bare relative; `./…` preserved; `../…` preserved; absolute → absolute paths.
+
+#### Triggers
+- Any change to filesystem display base/prefix rules or to README/SPEC examples reflecting them.
 
 ---
 


### PR DESCRIPTION
Add `Context.max_files` to Set 9 and a new Set 18 for filesystem display semantics to improve parity documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-1bb41c2c-de9b-4fdb-ae25-08334fff87b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1bb41c2c-de9b-4fdb-ae25-08334fff87b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

