### PR TITLE
Handle multiple explicit file paths

### DIFF
--- a/src/prin/adapters/filesystem.py
+++ b/src/prin/adapters/filesystem.py
@@ -230,13 +230,12 @@ class FileSystemSource(SourceAdapter):
                 return f"{display_prefix.rstrip('/')}/{rel}", f"{display_prefix.rstrip('/')}/{rel}"
             return rel, None
 
-        # Special case: if pattern is an exact existing file path, treat it as explicit
-        if pattern and not search_path:
+        # Special case: if pattern is an exact existing file path, also emit it explicitly.
+        # Do not return early; still traverse to allow pattern matching to include other files.
+        if pattern and search_path is None:
             try:
                 pattern_as_path = self.resolve(pattern)
                 if pattern_as_path.exists() and pattern_as_path.is_file():
-                    # This is an explicit file reference
-                    # Display relative to anchor when under it; otherwise absolute
                     if str(pattern_as_path).startswith(str(self.anchor) + os.sep):
                         rel = self._display_rel(pattern_as_path, self.anchor)
                         disp = rel
@@ -249,8 +248,7 @@ class FileSystemSource(SourceAdapter):
                         abs_path=PurePosixPath(str(pattern_as_path)),
                         explicit=True,
                     )
-                    return
-            except:
+            except Exception:
                 pass
 
         # If no pattern or empty pattern, list all files

--- a/src/prin/cli_common.py
+++ b/src/prin/cli_common.py
@@ -63,7 +63,7 @@ def _expand_cli_aliases(argv: list[str] | None) -> list[str]:
 class Context:
     # Field list should match CLI options.
     pattern: str = ""
-    search_path: str | None = None
+    paths: list[str] = field(default_factory=list)
     include_tests: bool = DEFAULT_INCLUDE_TESTS
     include_lock: bool = DEFAULT_INCLUDE_LOCK
     include_binary: bool = DEFAULT_INCLUDE_BINARY
@@ -169,7 +169,7 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         epilog=epilog,
     )
 
-    # What-then-where positional arguments
+    # What-then-where positional arguments (pattern + zero or more paths)
     parser.add_argument(
         "pattern",
         type=str,
@@ -178,11 +178,11 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         default="",
     )
     parser.add_argument(
-        "search_path",
+        "paths",
         type=str,
-        nargs="?",
-        help="Path to search in. Defaults to current directory if not specified.",
-        default=None,
+        nargs="*",
+        help="Zero or more paths (files or directories). If omitted, defaults to current directory.",
+        default=[],
     )
 
     # Uppercase short flags are boolean "include" flags.
@@ -303,7 +303,7 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
 
     return Context(
         pattern=args.pattern,
-        search_path=args.search_path,
+        paths=list(args.paths or []),
         include_tests=bool(args.include_tests),
         include_lock=bool(args.include_lock),
         include_binary=bool(args.include_binary),

--- a/src/prin/prin.py
+++ b/src/prin/prin.py
@@ -22,28 +22,68 @@ def main(*, argv: list[str] | None = None, writer: Writer | None = None) -> None
     # Global print budget shared across sources
     budget = FileBudget(ctx.max_files)
 
-    search_path = ctx.search_path
     pattern = ctx.pattern
 
-    # Determine source type based on search_path
-    if search_path and util.is_github_url(search_path):
-        # GitHub repository
-        gh_source = GitHubRepoSource(search_path)
-        gh_source.configure(ctx.replace(no_ignore=True))
-        printer = DepthFirstPrinter(gh_source, formatter=formatter, ctx=ctx)
-        printer.run_pattern(pattern, search_path, out_writer, budget=budget)
-    elif search_path and util.is_http_url(search_path):
-        # Website
-        ws_source = WebsiteSource(search_path)
-        ws_source.configure(ctx)
-        printer = DepthFirstPrinter(ws_source, formatter=formatter, ctx=ctx)
-        printer.run_pattern(pattern, search_path, out_writer, budget=budget)
-    else:
+    # If no paths are provided, default to current directory behavior (single run with None)
+    if not ctx.paths:
         # Filesystem (default)
         fs_source = FileSystemSource()
         fs_source.configure(ctx)
-        printer = DepthFirstPrinter(fs_source, formatter=formatter, ctx=ctx)
-        printer.run_pattern(pattern, search_path, out_writer, budget=budget)
+        fs_printer = DepthFirstPrinter(fs_source, formatter=formatter, ctx=ctx)
+
+        # If the pattern itself is an existing file path, emit it explicitly first
+        try:
+            p_as_path = fs_source.resolve(pattern)
+            if p_as_path.exists() and p_as_path.is_file():
+                # Print the exact file regardless of filters
+                fs_printer.run_pattern("", str(p_as_path), out_writer, budget=budget)
+        except Exception:
+            pass
+
+        fs_printer.run_pattern(pattern, None, out_writer, budget=budget)
+        return
+
+    # There are one or more paths. Share a single filesystem printer for all FS paths
+    fs_source = FileSystemSource()
+    fs_source.configure(ctx)
+    fs_printer = DepthFirstPrinter(fs_source, formatter=formatter, ctx=ctx)
+
+    # If the pattern itself is an existing file path, emit it explicitly once
+    try:
+        p_as_path = fs_source.resolve(pattern)
+        if p_as_path.exists() and p_as_path.is_file():
+            fs_printer.run_pattern("", str(p_as_path), out_writer, budget=budget)
+    except Exception:
+        pass
+
+    for token in ctx.paths:
+        if budget.spent():
+            break
+        if util.is_github_url(token):
+            gh_source = GitHubRepoSource(token)
+            gh_source.configure(ctx.replace(no_ignore=True))
+            gh_printer = DepthFirstPrinter(gh_source, formatter=formatter, ctx=ctx)
+            gh_printer.run_pattern(pattern, token, out_writer, budget=budget)
+            continue
+        if util.is_http_url(token):
+            ws_source = WebsiteSource(token)
+            ws_source.configure(ctx)
+            ws_printer = DepthFirstPrinter(ws_source, formatter=formatter, ctx=ctx)
+            ws_printer.run_pattern(pattern, token, out_writer, budget=budget)
+            continue
+
+        # Filesystem token: detect if file or directory
+        try:
+            resolved = fs_source.resolve(token)
+            if resolved.exists() and resolved.is_file():
+                # Force-print this file regardless of filters by using empty pattern
+                fs_printer.run_pattern("", token, out_writer, budget=budget)
+            else:
+                # Directory or non-existent; traverse with pattern (non-existent will yield nothing)
+                fs_printer.run_pattern(pattern, token, out_writer, budget=budget)
+        except Exception:
+            # On any resolution error, fall back to traversal attempt
+            fs_printer.run_pattern(pattern, token, out_writer, budget=budget)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow `prin` to accept multiple paths and treat the pattern as an explicit file if it exists, simplifying CLI usage and enabling multi-target searches.

The previous "what-then-where" model with a single `search_path` is replaced by an "optional pattern + N paths" model. This allows users to specify multiple files and directories directly. If the initial `pattern` argument itself resolves to an existing file, it is explicitly printed (bypassing filters) while still being used as a pattern for traversal in any specified directories. This ensures that `prin README.md .` prints `README.md` explicitly and also searches for `README.md` within the current directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-e400675e-d20b-4866-88d5-fad1d4f4e952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e400675e-d20b-4866-88d5-fad1d4f4e952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

