### PR TITLE
Prioritize noise file extensions for exclusion

### DIFF
--- a/src/prin/defaults.py
+++ b/src/prin/defaults.py
@@ -35,6 +35,22 @@ DEFAULT_EXCLUSIONS: list[Pattern] = [
     re.compile(r"(^|/)venv(/|$)"),
     # Minified assets
     Glob("*.min.*"),
+    # Generated source artifacts (TypeScript, source maps)
+    Glob("*.d.ts"),
+    Glob("*.map"),
+    # Version control artifacts
+    Glob("*.orig"),
+    Glob("*.rej"),
+    # Editor backup files
+    Glob("*.bak"),
+    Glob("*.old"),
+    # Additional editor temporary files
+    Glob("*.swn"),  # Vim (complements .swp, .swo)
+    Glob("*.temp"),
+    # Language/IDE-specific generated files
+    Glob("*.d"),  # C/C++ dependency files
+    Glob("*.iml"),  # IntelliJ IDEA modules
+    Glob("*.user"),  # Visual Studio user files (includes .csproj.user, .vbproj.user, etc.)
     re.compile("DerivedData"),
     re.compile("Pods"),
     re.compile(r"Carthage/Build"),


### PR DESCRIPTION
Add common non-binary "noise" file extensions to default exclusions to reduce clutter for developers across various ecosystems.

---
<a href="https://cursor.com/background-agent?bcId=bc-51d2fd85-ded8-4fef-bc3f-6b2b310959ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-51d2fd85-ded8-4fef-bc3f-6b2b310959ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

