### PR TITLE
Add no dependencies flag and categories

### DIFF
--- a/PARITIES.md
+++ b/PARITIES.md
@@ -97,13 +97,16 @@ See "Maintaining `PARITIES.md`" section at the bottom of this file for detailed 
 
 #### Members
 - `src/prin/cli_common.py`: CLI flags, `Context` fields, CLI documentation in `parse_common_args`.
-- `src/prin/defaults.py`: patterns in `DEFAULT_EXCLUSIONS`, `DEFAULT_TEST_EXCLUSIONS`, `DEFAULT_LOCK_EXCLUSIONS`, `DEFAULT_BINARY_EXCLUSIONS`, `DEFAULT_DOC_EXTENSIONS`, `Hidden`; default CLI configuration by all the `DEFAULT_*` scalar constants.
-- `README.md` sections: “Sane Defaults for LLM Input”, “Output Control”, CLI Options”.
+- `src/prin/defaults.py`: patterns in `DEFAULT_EXCLUSIONS`, `DEFAULT_TEST_EXCLUSIONS`, `DEFAULT_LOCK_EXCLUSIONS`, `DEFAULT_DEPENDENCY_EXCLUSIONS`, `DEFAULT_BINARY_EXCLUSIONS`, `DEFAULT_DOC_EXTENSIONS`, `Hidden`; default CLI configuration by all the `DEFAULT_*` scalar constants.
+- `README.md` sections: "Sane Defaults for LLM Input", "Output Control", CLI Options".
+- `tests/conftest.py`: `VFS` fixture with categorized file dictionaries including `dependency_spec_files` and `build_dependency_files`.
+- `tests/test_dependency_flag.py`: tests for `--no-dependencies` flag.
 
 #### Contract
 - Filter flags exposed by the CLI in `cli_common.py` must have corresponding DEFAULT_* patterns and DEFAULT_* feature flags in `defaults.py`, `Context` fields, representation in `README.md` in specified sections, synced CLI help in `parse_common_args`, mocks in `conftest.fs_root` and a field in `conftest.VFS`.
  - Hidden category in the FS fixture is represented by files under dot-directories (e.g., `.github/config`, `app/submodule/.git/config`); directories themselves are not printed.
  - Build directory exclusion uses path-bounded regex `(^|/)build(/|$)`; minified assets are excluded by default via `*.min.*`; doc extensions include `*.1`.
+ - Dependency files category: `dependency_spec_files` contains dependency specification files (package.json, pyproject.toml, requirements.txt, pom.xml, etc.) excluded by default with `--no-dependencies`; `build_dependency_files` contains installed dependencies (node_modules/, .venv/) excluded by default via `DEFAULT_EXCLUSIONS`.
 
 #### Triggers
 - Adding/removing/renaming a filter category; changing category semantics.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ See [Development Cycle (Tight TDD Loop)](AGENTS.md) for more details.
 
 - [x] `-K`, `--include-lock`: Include lock files (e.g., package-lock.json, poetry.lock, Cargo.lock).
 
+- [x] `--no-dependencies`: Exclude dependency specification files (e.g., package.json, pyproject.toml, requirements.txt, pom.xml, Cargo.toml).
+
 - [x] `-d`, `--no-docs`: Exclude documentation files (e.g., *.md, *.rst, *.txt).
 
 - [x] `-M`, `--include-empty`: Include empty files and semantically-empty Python files.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,6 @@ Guiding principle: maximize filesystem feature breadth and polish before investi
   * .a - Static library
   * .otc, .ttc, .pfb, .pfm - Additional font files (.otf, .ttf, .woff, .woff2, .eot already handled)
 - Detect binary files dynamically like `fd` does.
-- `--no-package`, `--no-requirements` (`package.json`, `pyproject.toml`, `requirements.txt`, etc.)
 - `--no-style`, `--no-css` (`css`, `scss`, `sass`, etc.)
 - `--no-config` (`json`, `yaml`, `toml`, `ini`, `cfg`, etc.)
 - `--no-scripts`: exclude shell scripts and `scripts/` directory (`*sh`, `bat`, `ps1`, `scripts/` dir, etc.)

--- a/src/prin/adapters/filesystem.py
+++ b/src/prin/adapters/filesystem.py
@@ -147,7 +147,7 @@ class FileSystemSource(SourceAdapter):
         stack: list[tuple[Path, int]] = [(start, 0)]
         while stack:
             current, current_depth = stack.pop()
-            
+
             try:
                 with os.scandir(current) as it:
                     dirs: list[os.DirEntry] = []

--- a/src/prin/cli_common.py
+++ b/src/prin/cli_common.py
@@ -10,12 +10,14 @@ from typing import Literal
 
 from prin.defaults import (
     DEFAULT_BINARY_EXCLUSIONS,
+    DEFAULT_DEPENDENCY_EXCLUSIONS,
     DEFAULT_DOC_EXTENSIONS,
     DEFAULT_EXACT_DEPTH,
     DEFAULT_EXCLUDE_FILTER,
     DEFAULT_EXCLUSIONS,
     DEFAULT_EXTENSIONS_FILTER,
     DEFAULT_INCLUDE_BINARY,
+    DEFAULT_INCLUDE_DEPENDENCIES,
     DEFAULT_INCLUDE_EMPTY,
     DEFAULT_INCLUDE_HIDDEN,
     DEFAULT_INCLUDE_LOCK,
@@ -68,6 +70,7 @@ class Context:
     paths: list[str] = field(default_factory=list)
     include_tests: bool = DEFAULT_INCLUDE_TESTS
     include_lock: bool = DEFAULT_INCLUDE_LOCK
+    include_dependencies: bool = DEFAULT_INCLUDE_DEPENDENCIES
     include_binary: bool = DEFAULT_INCLUDE_BINARY
     no_docs: bool = DEFAULT_NO_DOCS
     include_empty: bool = DEFAULT_INCLUDE_EMPTY
@@ -110,6 +113,9 @@ class Context:
 
         if not self.include_lock:
             exclusions.extend(DEFAULT_LOCK_EXCLUSIONS)
+
+        if not self.include_dependencies:
+            exclusions.extend(DEFAULT_DEPENDENCY_EXCLUSIONS)
 
         if not self.include_binary:
             exclusions.extend(DEFAULT_BINARY_EXCLUSIONS)
@@ -205,6 +211,13 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         action="store_true",
         help="Include lock files (e.g. package-lock.json, poetry.lock, Cargo.lock).",
         default=DEFAULT_INCLUDE_LOCK,
+    )
+    parser.add_argument(
+        "--no-dependencies",
+        action="store_false",
+        dest="include_dependencies",
+        help="Exclude dependency specification files (e.g. package.json, pyproject.toml, requirements.txt, pom.xml, Cargo.toml).",
+        default=DEFAULT_INCLUDE_DEPENDENCIES,
     )
     parser.add_argument(
         "-a",  # Deviates from 'fd' that has '-a' for '--absolute-path'. Compat with 'rg'.
@@ -335,6 +348,7 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         paths=list(args.paths or []),
         include_tests=bool(args.include_tests),
         include_lock=bool(args.include_lock),
+        include_dependencies=bool(args.include_dependencies),
         include_binary=bool(args.include_binary),
         no_docs=bool(args.no_docs),
         include_empty=bool(args.include_empty),

--- a/src/prin/defaults.py
+++ b/src/prin/defaults.py
@@ -98,8 +98,7 @@ DEFAULT_TEST_EXCLUSIONS: list[Pattern] = [
 DEFAULT_LOCK_EXCLUSIONS: list[Pattern] = [
     Glob("*.lock"),
     Glob("*.lockfile"),
-    Glob("*lock.json"),
-    Glob("*lock.yaml"),
+    Glob("*lock.*"),
     # Go
     re.compile(r"go\.sum"),
     # Swift/iOS

--- a/src/prin/defaults.py
+++ b/src/prin/defaults.py
@@ -77,7 +77,13 @@ DEFAULT_EXCLUSIONS: list[Pattern] = [
 ]
 
 
-DEFAULT_DOC_EXTENSIONS: list[Glob] = [Glob("*.md"), Glob("*.rst"), Glob("*.mdx"), Glob("*.1"), Glob("*.rtf")]
+DEFAULT_DOC_EXTENSIONS: list[Glob] = [
+    Glob("*.md"),
+    Glob("*.rst"),
+    Glob("*.mdx"),
+    Glob("*.1"),
+    Glob("*.rtf"),
+]
 
 
 DEFAULT_TEST_EXCLUSIONS: list[Pattern] = [
@@ -95,11 +101,61 @@ DEFAULT_LOCK_EXCLUSIONS: list[Pattern] = [
     # JavaScript/Node
     re.compile(r"package-lock\.json"),
     re.compile(r"pnpm-lock\.yaml"),
+    re.compile(r"yarn\.lock"),
+    # Go
     re.compile(r"go\.sum"),
-    re.compile(r"bun\.lockb"),
+    # Rust
+    re.compile(r"Cargo\.lock"),
+    # Swift/iOS
     re.compile(r"Package\.resolved"),
+    re.compile(r"Podfile\.lock"),
+    # Dart/Flutter
+    re.compile(r"pubspec\.lock"),
+    # Ruby
+    re.compile(r"Gemfile\.lock"),
+    # PHP
+    re.compile(r"composer\.lock"),
+    # Other
+    re.compile(r"bun\.lockb"),
     re.compile(r"Cartfile\.resolved"),
     re.compile(r"packages\.lock\.json"),
+]
+
+
+DEFAULT_DEPENDENCY_EXCLUSIONS: list[Pattern] = [
+    # JavaScript/TypeScript/Node.js
+    re.compile(r"package\.json"),
+    # Python
+    re.compile(r"pyproject\.toml"),
+    re.compile(r"requirements\.txt"),
+    re.compile(r"requirements-.*\.txt"),
+    re.compile(r".*requirements\.txt"),
+    # Java
+    re.compile(r"pom\.xml"),
+    re.compile(r"build\.gradle"),
+    re.compile(r"build\.gradle\.kts"),
+    # C#
+    Glob("*.csproj"),
+    re.compile(r"packages\.config"),
+    # C++
+    re.compile(r"conanfile\.txt"),
+    re.compile(r"conanfile\.py"),
+    re.compile(r"vcpkg\.json"),
+    re.compile(r"CMakeLists\.txt"),
+    # PHP
+    re.compile(r"composer\.json"),
+    # Go
+    re.compile(r"go\.mod"),
+    # Rust
+    re.compile(r"Cargo\.toml"),
+    # Swift
+    re.compile(r"Package\.swift"),
+    re.compile(r"Podfile"),
+    # Kotlin (uses Gradle/Maven like Java)
+    # Dart/Flutter
+    re.compile(r"pubspec\.yaml"),
+    # Ruby
+    re.compile(r"Gemfile"),
 ]
 
 
@@ -193,6 +249,7 @@ DEFAULT_BINARY_EXCLUSIONS: list[Pattern] = [
 DEFAULT_RUN_PATH = "."
 DEFAULT_INCLUDE_TESTS = False
 DEFAULT_INCLUDE_LOCK = False
+DEFAULT_INCLUDE_DEPENDENCIES = True
 DEFAULT_INCLUDE_BINARY = False
 DEFAULT_NO_DOCS = False
 DEFAULT_INCLUDE_EMPTY = False

--- a/src/prin/defaults.py
+++ b/src/prin/defaults.py
@@ -98,27 +98,15 @@ DEFAULT_TEST_EXCLUSIONS: list[Pattern] = [
 DEFAULT_LOCK_EXCLUSIONS: list[Pattern] = [
     Glob("*.lock"),
     Glob("*.lockfile"),
-    # JavaScript/Node
-    re.compile(r"package-lock\.json"),
-    re.compile(r"pnpm-lock\.yaml"),
-    re.compile(r"yarn\.lock"),
+    Glob("*lock.json"),
+    Glob("*lock.yaml"),
     # Go
     re.compile(r"go\.sum"),
-    # Rust
-    re.compile(r"Cargo\.lock"),
     # Swift/iOS
     re.compile(r"Package\.resolved"),
-    re.compile(r"Podfile\.lock"),
-    # Dart/Flutter
-    re.compile(r"pubspec\.lock"),
-    # Ruby
-    re.compile(r"Gemfile\.lock"),
-    # PHP
-    re.compile(r"composer\.lock"),
     # Other
     re.compile(r"bun\.lockb"),
     re.compile(r"Cartfile\.resolved"),
-    re.compile(r"packages\.lock\.json"),
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,8 @@ class VFS(NamedTuple):
     binary_files: dict[str, str]
     hidden_files: dict[str, str]
     test_files: dict[str, str]
-    dependency_files: dict[str, str]
+    build_dependency_files: dict[str, str]
+    dependency_spec_files: dict[str, str]
     artifact_files: dict[str, str]
     cache_files: dict[str, str]
     log_files: dict[str, str]
@@ -106,9 +107,23 @@ def fs_root() -> VFS:
         "app/mod.test.py": "def mod_test():\n    assert True\n",
         "tests/howto.txt": "How to run tests\n",  # Should be excluded because the tests/ dir.
     }
-    dependency_files: dict[str, str] = {
+    build_dependency_files: dict[str, str] = {
         "node_modules/pkg/index.js": "console.log('x');\n",
         ".venv/lib/python3.13/site-packages/decorator.py": "POS = inspect.Parameter.POSITIONAL_OR_KEYWORD\n",
+    }
+    dependency_spec_files: dict[str, str] = {
+        "package.json": '{"name": "test-pkg", "version": "1.0.0"}\n',
+        "pyproject.toml": '[project]\nname = "test-project"\n',
+        "requirements.txt": "requests==2.31.0\n",
+        "requirements-dev.txt": "pytest==8.0.0\n",
+        "pom.xml": '<?xml version="1.0"?>\n<project></project>\n',
+        "build.gradle": 'plugins { id "java" }\n',
+        "Cargo.toml": '[package]\nname = "test"\n',
+        "go.mod": "module example.com/test\n",
+        "Gemfile": 'source "https://rubygems.org"\n',
+        "composer.json": '{"name": "test/pkg"}\n',
+        "Podfile": 'platform :ios, "14.0"\n',
+        "pubspec.yaml": "name: test_app\n",
     }
     artifact_files: dict[str, str] = {
         "build/artifact.o": "OBJ\n",
@@ -142,7 +157,8 @@ def fs_root() -> VFS:
         binary_files,
         hidden_files,
         test_files,
-        dependency_files,
+        build_dependency_files,
+        dependency_spec_files,
         artifact_files,
         cache_files,
         log_files,
@@ -163,7 +179,8 @@ def fs_root() -> VFS:
         **binary_files,
         **hidden_files,
         **test_files,
-        **dependency_files,
+        **build_dependency_files,
+        **dependency_spec_files,
         **artifact_files,
         **cache_files,
         **log_files,
@@ -215,7 +232,8 @@ def fs_root() -> VFS:
             binary_files=binary_files,
             hidden_files=hidden_files,
             test_files=test_files,
-            dependency_files=dependency_files,
+            build_dependency_files=build_dependency_files,
+            dependency_spec_files=dependency_spec_files,
             artifact_files=artifact_files,
             cache_files=cache_files,
             log_files=log_files,

--- a/tests/test_dependency_flag.py
+++ b/tests/test_dependency_flag.py
@@ -1,0 +1,144 @@
+"""Tests for --no-dependencies flag."""
+
+from prin.adapters.filesystem import FileSystemSource
+from prin.cli_common import Context, parse_common_args
+from prin.core import DepthFirstPrinter, StringWriter
+from prin.defaults import DEFAULT_DEPENDENCY_EXCLUSIONS
+from prin.formatters import XmlFormatter
+
+
+def test_include_dependencies_default(fs_root):
+    """By default, dependency spec files are included."""
+    ctx = parse_common_args(["", str(fs_root.root)])
+    assert ctx.include_dependencies is True
+    # Dependency exclusions should not be in the exclusions list
+    for dep_pattern in DEFAULT_DEPENDENCY_EXCLUSIONS:
+        assert dep_pattern not in ctx.exclusions
+
+    # Run prin and check that dependency spec files are in output
+    source = FileSystemSource(anchor=fs_root.root)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", None, writer)
+    output = writer.text()
+
+    # Check that some dependency files are present
+    assert "package.json" in output
+    assert "pyproject.toml" in output
+    assert "requirements.txt" in output
+
+
+def test_no_dependencies_flag_excludes_dependency_files(fs_root):
+    """--no-dependencies excludes dependency specification files."""
+    ctx = parse_common_args(["--no-dependencies", "", str(fs_root.root)])
+    assert ctx.include_dependencies is False
+    # Dependency exclusions should be in the exclusions list
+    for dep_pattern in DEFAULT_DEPENDENCY_EXCLUSIONS:
+        assert dep_pattern in ctx.exclusions
+
+    # Run prin with --no-dependencies
+    source = FileSystemSource(anchor=fs_root.root)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", None, writer)
+    output = writer.text()
+
+    # Check that dependency spec files are excluded
+    assert "package.json" not in output
+    assert "pyproject.toml" not in output
+    assert "requirements.txt" not in output
+    assert "requirements-dev.txt" not in output
+    assert "pom.xml" not in output
+    assert "build.gradle" not in output
+    assert "Cargo.toml" not in output
+    assert "go.mod" not in output
+    assert "Gemfile" not in output
+    assert "composer.json" not in output
+    assert "Podfile" not in output
+    assert "pubspec.yaml" not in output
+
+
+def test_no_dependencies_does_not_exclude_lock_files(fs_root):
+    """--no-dependencies does not exclude lock files (they have their own flag)."""
+    # Run with --no-dependencies but without --include-lock
+    ctx = parse_common_args(["--no-dependencies", "", str(fs_root.root)])
+    source = FileSystemSource(anchor=fs_root.root)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", None, writer)
+    output = writer.text()
+
+    # Lock files should still be excluded by default (not included without --include-lock)
+    assert "poetry.lock" not in output
+    assert "package-lock.json" not in output
+
+
+def test_no_dependencies_with_include_lock(fs_root):
+    """--no-dependencies with --include-lock includes lock files but not spec files."""
+    ctx = parse_common_args(["--no-dependencies", "--include-lock", "", str(fs_root.root)])
+    source = FileSystemSource(anchor=fs_root.root)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", None, writer)
+    output = writer.text()
+
+    # Lock files should be included
+    assert "poetry.lock" in output
+    assert "package-lock.json" in output
+    assert "uv.lock" in output
+
+    # Spec files should still be excluded
+    assert "package.json" not in output
+    assert "pyproject.toml" not in output
+
+
+def test_no_dependencies_does_not_exclude_regular_files(fs_root):
+    """--no-dependencies does not exclude regular code files."""
+    ctx = parse_common_args(["--no-dependencies", "", str(fs_root.root)])
+    source = FileSystemSource(anchor=fs_root.root)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", None, writer)
+    output = writer.text()
+
+    # Regular files should still be present
+    assert "foo.py" in output
+    assert "src/app.py" in output
+    assert "src/util.py" in output
+
+
+def test_explicit_dependency_file_included(fs_root):
+    """Explicitly specified dependency file is included even with --no-dependencies."""
+    package_json = fs_root.root / "package.json"
+    ctx = Context(include_dependencies=False)
+    source = FileSystemSource(anchor=package_json)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", package_json, writer)
+    output = writer.text()
+
+    # Explicitly specified file should be included
+    assert "package.json" in output
+    assert '"name": "test-pkg"' in output
+
+
+def test_no_exclude_overrides_no_dependencies(fs_root):
+    """--no-exclude / --include-all overrides --no-dependencies."""
+    ctx = parse_common_args(["--no-dependencies", "--no-exclude", "", str(fs_root.root)])
+    source = FileSystemSource(anchor=fs_root.root)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", None, writer)
+    output = writer.text()
+
+    # Everything should be included
+    assert "package.json" in output
+    assert "pyproject.toml" in output
+    assert "requirements.txt" in output


### PR DESCRIPTION
Implement the `--no-dependencies` flag to allow users to exclude dependency specification files from the output.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3e92892-7559-493f-8dd3-7e5251e58af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a3e92892-7559-493f-8dd3-7e5251e58af9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

