### PR TITLE
Add --no-style flag to filter stylesheet files

### DIFF
--- a/PARITIES.md
+++ b/PARITIES.md
@@ -97,7 +97,7 @@ See "Maintaining `PARITIES.md`" section at the bottom of this file for detailed 
 
 #### Members
 - `src/prin/cli_common.py`: CLI flags, `Context` fields, CLI documentation in `parse_common_args`.
-- `src/prin/defaults.py`: patterns in `DEFAULT_EXCLUSIONS`, `DEFAULT_TEST_EXCLUSIONS`, `DEFAULT_LOCK_EXCLUSIONS`, `DEFAULT_DEPENDENCY_EXCLUSIONS`, `DEFAULT_BINARY_EXCLUSIONS`, `DEFAULT_DOC_EXTENSIONS`, `Hidden`; default CLI configuration by all the `DEFAULT_*` scalar constants.
+- `src/prin/defaults.py`: patterns in `DEFAULT_EXCLUSIONS`, `DEFAULT_TEST_EXCLUSIONS`, `DEFAULT_LOCK_EXCLUSIONS`, `DEFAULT_DEPENDENCY_EXCLUSIONS`, `DEFAULT_BINARY_EXCLUSIONS`, `DEFAULT_DOC_EXTENSIONS`, `DEFAULT_STYLESHEET_EXTENSIONS`, `Hidden`; default CLI configuration by all the `DEFAULT_*` scalar constants.
 - `README.md` sections: "Sane Defaults for LLM Input", "Output Control", CLI Options".
 - `tests/conftest.py`: `VFS` fixture with categorized file dictionaries including `dependency_spec_files` and `build_dependency_files`.
 - `tests/test_dependency_flag.py`: tests for `--no-dependencies` flag.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ See [Development Cycle (Tight TDD Loop)](AGENTS.md) for more details.
 - [x] `--no-dependencies`: Exclude dependency specification files (e.g., package.json, pyproject.toml, requirements.txt, pom.xml, Cargo.toml).
 
 - [x] `-d`, `--no-docs`: Exclude documentation files (e.g., *.md, *.rst, *.txt).
+- [x] `--no-style`, `--no-css`: Exclude stylesheet files (e.g., *.css, *.scss, *.sass, *.less, *.styl, *.stylus, *.pcss, *.postcss, *.sss).
 
 - [x] `-M`, `--include-empty`: Include empty files and semantically-empty Python files.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,7 +27,6 @@ Guiding principle: maximize filesystem feature breadth and polish before investi
   * .a - Static library
   * .otc, .ttc, .pfb, .pfm - Additional font files (.otf, .ttf, .woff, .woff2, .eot already handled)
 - Detect binary files dynamically like `fd` does.
-- `--no-style`, `--no-css` (`css`, `scss`, `sass`, etc.)
 - `--no-config` (`json`, `yaml`, `toml`, `ini`, `cfg`, etc.)
 - `--no-scripts`: exclude shell scripts and `scripts/` directory (`*sh`, `bat`, `ps1`, `scripts/` dir, etc.)
 - `--no-web` (`html*`, stylesheets, `*js*`, `ts*`, etc.)  // This would be the first flag overlapping another flag (e.g., `--no-style`). I don‘t know if this hurts product precision.

--- a/SPEC.md
+++ b/SPEC.md
@@ -111,6 +111,7 @@ This allows combining explicit file output with pattern-based search in a single
 ### Exclusions
 - `-E`, `--exclude <glob|regex>` (repeatable): exclude paths matching the pattern; matches full display-relative path.
 - `-d`, `--no-docs`: exclude documentation files (e.g., `*.md`, `*.rst`, `*.txt`).
+- `--no-style`, `--no-css`: exclude stylesheet files (e.g., `*.css`, `*.scss`, `*.sass`, `*.less`, `*.styl`, `*.stylus`, `*.pcss`, `*.postcss`, `*.sss`).
 
 ### Inclusions
 - `-H`, `--hidden`: include dot-files and dot-directories.

--- a/src/prin/cli_common.py
+++ b/src/prin/cli_common.py
@@ -26,9 +26,11 @@ from prin.defaults import (
     DEFAULT_MAX_DEPTH,
     DEFAULT_MIN_DEPTH,
     DEFAULT_NO_DOCS,
+    DEFAULT_NO_STYLESHEETS,
     DEFAULT_NO_EXCLUDE,
     DEFAULT_NO_IGNORE,
     DEFAULT_ONLY_HEADERS,
+    DEFAULT_STYLESHEET_EXTENSIONS,
     DEFAULT_TAG,
     DEFAULT_TAG_CHOICES,
     DEFAULT_TEST_EXCLUSIONS,
@@ -73,6 +75,7 @@ class Context:
     include_dependencies: bool = DEFAULT_INCLUDE_DEPENDENCIES
     include_binary: bool = DEFAULT_INCLUDE_BINARY
     no_docs: bool = DEFAULT_NO_DOCS
+    no_stylesheets: bool = DEFAULT_NO_STYLESHEETS
     include_empty: bool = DEFAULT_INCLUDE_EMPTY
     include_hidden: bool = DEFAULT_INCLUDE_HIDDEN
     extensions: list[Pattern] = field(default_factory=lambda: list(DEFAULT_EXTENSIONS_FILTER))
@@ -125,6 +128,9 @@ class Context:
 
         if self.no_docs:
             exclusions.extend(DEFAULT_DOC_EXTENSIONS)
+
+        if self.no_stylesheets:
+            exclusions.extend(DEFAULT_STYLESHEET_EXTENSIONS)
 
         self.exclusions = exclusions
 
@@ -235,6 +241,14 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         action="store_true",
         help=f"Exclude {', '.join(DEFAULT_DOC_EXTENSIONS)} files.",
         default=DEFAULT_NO_DOCS,
+    )
+    parser.add_argument(
+        "--no-style",
+        "--no-css",
+        action="store_true",
+        dest="no_stylesheets",
+        help=f"Exclude {', '.join(DEFAULT_STYLESHEET_EXTENSIONS)} files.",
+        default=DEFAULT_NO_STYLESHEETS,
     )
     parser.add_argument(
         "-M",
@@ -351,6 +365,7 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         include_dependencies=bool(args.include_dependencies),
         include_binary=bool(args.include_binary),
         no_docs=bool(args.no_docs),
+        no_stylesheets=bool(args.no_stylesheets),
         include_empty=bool(args.include_empty),
         only_headers=bool(args.only_headers),
         extensions=list(args.extension or []),

--- a/src/prin/defaults.py
+++ b/src/prin/defaults.py
@@ -86,6 +86,19 @@ DEFAULT_DOC_EXTENSIONS: list[Glob] = [
 ]
 
 
+DEFAULT_STYLESHEET_EXTENSIONS: list[Glob] = [
+    Glob("*.css"),
+    Glob("*.scss"),
+    Glob("*.sass"),
+    Glob("*.less"),
+    Glob("*.styl"),
+    Glob("*.stylus"),
+    Glob("*.pcss"),
+    Glob("*.postcss"),
+    Glob("*.sss"),
+]
+
+
 DEFAULT_TEST_EXCLUSIONS: list[Pattern] = [
     re.compile(r".*\.test(\..+)?"),
     re.compile(r"tests?/"),
@@ -239,6 +252,7 @@ DEFAULT_INCLUDE_LOCK = False
 DEFAULT_INCLUDE_DEPENDENCIES = True
 DEFAULT_INCLUDE_BINARY = False
 DEFAULT_NO_DOCS = False
+DEFAULT_NO_STYLESHEETS = False
 DEFAULT_INCLUDE_EMPTY = False
 DEFAULT_ONLY_HEADERS = False
 DEFAULT_EXTENSIONS_FILTER = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ class VFS(NamedTuple):
     test_files: dict[str, str]
     build_dependency_files: dict[str, str]
     dependency_spec_files: dict[str, str]
+    stylesheet_files: dict[str, str]
     artifact_files: dict[str, str]
     cache_files: dict[str, str]
     log_files: dict[str, str]
@@ -125,6 +126,17 @@ def fs_root() -> VFS:
         "Podfile": 'platform :ios, "14.0"\n',
         "pubspec.yaml": "name: test_app\n",
     }
+    stylesheet_files: dict[str, str] = {
+        "assets/styles/main.css": "body { color: red; }\n",
+        "assets/styles/theme.scss": "$primary: #00f;\n",
+        "assets/styles/legacy.sass": "body\n  color: #0f0\n",
+        "assets/styles/vars.less": "@primary: #333;\n",
+        "assets/styles/editor.styl": "body\n  color #fff\n",
+        "assets/styles/layout.stylus": "body\n  background #000\n",
+        "assets/styles/custom.pcss": ":root {\n  --gap: 1rem;\n}\n",
+        "assets/styles/postcss.postcss": ":root {\n  --font: 'Inter';\n}\n",
+        "assets/styles/sugar.sss": ":root\n  color: #123\n",
+    }
     artifact_files: dict[str, str] = {
         "build/artifact.o": "OBJ\n",
         "dist/regular.js": "console.log('dist/regular.js');\n",  # Should be excluded because of the dist/ dir.
@@ -159,6 +171,7 @@ def fs_root() -> VFS:
         test_files,
         build_dependency_files,
         dependency_spec_files,
+        stylesheet_files,
         artifact_files,
         cache_files,
         log_files,
@@ -181,6 +194,7 @@ def fs_root() -> VFS:
         **test_files,
         **build_dependency_files,
         **dependency_spec_files,
+        **stylesheet_files,
         **artifact_files,
         **cache_files,
         **log_files,
@@ -234,6 +248,7 @@ def fs_root() -> VFS:
             test_files=test_files,
             build_dependency_files=build_dependency_files,
             dependency_spec_files=dependency_spec_files,
+            stylesheet_files=stylesheet_files,
             artifact_files=artifact_files,
             cache_files=cache_files,
             log_files=log_files,

--- a/tests/test_stylesheet_flag.py
+++ b/tests/test_stylesheet_flag.py
@@ -1,0 +1,71 @@
+"""Tests for --no-style / --no-css flags."""
+
+from prin.adapters.filesystem import FileSystemSource
+from prin.cli_common import Context, parse_common_args
+from prin.core import DepthFirstPrinter, StringWriter
+from prin.defaults import DEFAULT_STYLESHEET_EXTENSIONS
+from prin.formatters import XmlFormatter
+
+
+def _run_prin(ctx, root):
+    source = FileSystemSource(anchor=root)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", None, writer)
+    return writer.text()
+
+
+def test_stylesheets_included_by_default(fs_root):
+    ctx = parse_common_args(["", str(fs_root.root)])
+    assert ctx.no_stylesheets is False
+    for pattern in DEFAULT_STYLESHEET_EXTENSIONS:
+        assert pattern not in ctx.exclusions
+
+    output = _run_prin(ctx, fs_root.root)
+    assert "assets/styles/main.css" in output
+    assert "assets/styles/theme.scss" in output
+    assert "assets/styles/legacy.sass" in output
+
+
+def test_no_style_flag_excludes_stylesheets(fs_root):
+    ctx = parse_common_args(["--no-style", "", str(fs_root.root)])
+    assert ctx.no_stylesheets is True
+    for pattern in DEFAULT_STYLESHEET_EXTENSIONS:
+        assert pattern in ctx.exclusions
+
+    output = _run_prin(ctx, fs_root.root)
+    for path in fs_root.stylesheet_files:
+        assert path not in output
+
+
+def test_no_css_alias_matches_no_style(fs_root):
+    ctx_alias = parse_common_args(["--no-css", "", str(fs_root.root)])
+    ctx_flag = parse_common_args(["--no-style", "", str(fs_root.root)])
+
+    assert ctx_alias.no_stylesheets is True
+    assert ctx_alias.exclusions == ctx_flag.exclusions
+
+
+def test_explicit_stylesheet_is_included(fs_root):
+    explicit_path = fs_root.root / "assets/styles/main.css"
+    ctx = Context(no_stylesheets=True)
+    source = FileSystemSource(anchor=explicit_path)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", explicit_path, writer)
+    output = writer.text()
+
+    assert "assets/styles/main.css" in output
+    assert "body { color: red; }" in output
+
+
+def test_no_exclude_overrides_no_style(fs_root):
+    ctx = parse_common_args(["--no-style", "--no-exclude", "", str(fs_root.root)])
+    assert ctx.no_exclude is True
+    assert ctx.exclusions == []
+
+    output = _run_prin(ctx, fs_root.root)
+    assert "assets/styles/main.css" in output
+    assert "assets/styles/custom.pcss" in output


### PR DESCRIPTION
## Summary
- add DEFAULT_STYLESHEET_EXTENSIONS and DEFAULT_NO_STYLESHEETS defaults and expose a --no-style/--no-css CLI flag that toggles them
- document the new option and update parity records and roadmap now that the feature exists
- extend the filesystem fixture with stylesheet samples and cover the new flag with targeted tests

## Testing
- ./test.sh tests/test_stylesheet_flag.py

------
https://chatgpt.com/codex/tasks/task_e_68dec5331d7c8332af25e2a77afbe05a