### PR TITLE
Add filesystem --no-scripts exclusion flag

### DIFF
--- a/PARITIES.md
+++ b/PARITIES.md
@@ -98,6 +98,7 @@ See "Maintaining `PARITIES.md`" section at the bottom of this file for detailed 
 #### Members
 - `src/prin/cli_common.py`: CLI flags, `Context` fields, CLI documentation in `parse_common_args`.
 - `src/prin/defaults.py`: patterns in `DEFAULT_EXCLUSIONS`, `DEFAULT_TEST_EXCLUSIONS`, `DEFAULT_LOCK_EXCLUSIONS`, `DEFAULT_DEPENDENCY_EXCLUSIONS`, `DEFAULT_BINARY_EXCLUSIONS`, `DEFAULT_DOC_EXTENSIONS`, `DEFAULT_STYLESHEET_EXTENSIONS`, `Hidden`; default CLI configuration by all the `DEFAULT_*` scalar constants.
+- `src/prin/defaults.py`: patterns in `DEFAULT_EXCLUSIONS`, `DEFAULT_TEST_EXCLUSIONS`, `DEFAULT_LOCK_EXCLUSIONS`, `DEFAULT_DEPENDENCY_EXCLUSIONS`, `DEFAULT_BINARY_EXCLUSIONS`, `DEFAULT_DOC_EXTENSIONS`, `DEFAULT_STYLESHEET_EXTENSIONS`, `DEFAULT_SCRIPT_EXCLUSIONS`, `Hidden`; default CLI configuration by all the `DEFAULT_*` scalar constants.
 - `README.md` sections: "Sane Defaults for LLM Input", "Output Control", CLI Options".
 - `tests/conftest.py`: `VFS` fixture with categorized file dictionaries including `dependency_spec_files` and `build_dependency_files`.
 - `tests/test_dependency_flag.py`: tests for `--no-dependencies` flag.

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ See [Development Cycle (Tight TDD Loop)](AGENTS.md) for more details.
 - [x] `--no-dependencies`: Exclude dependency specification files (e.g., package.json, pyproject.toml, requirements.txt, pom.xml, Cargo.toml).
 
 - [x] `-d`, `--no-docs`: Exclude documentation files (e.g., *.md, *.rst, *.txt).
+- [x] `--no-scripts`: Exclude shell and automation scripts (e.g., *.sh, *.ps1, *.bat) and `scripts/` directories.
 - [x] `--no-style`, `--no-css`: Exclude stylesheet files (e.g., *.css, *.scss, *.sass, *.less, *.styl, *.stylus, *.pcss, *.postcss, *.sss).
 
 - [x] `-M`, `--include-empty`: Include empty files and semantically-empty Python files.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,6 @@ Guiding principle: maximize filesystem feature breadth and polish before investi
   * .otc, .ttc, .pfb, .pfm - Additional font files (.otf, .ttf, .woff, .woff2, .eot already handled)
 - Detect binary files dynamically like `fd` does.
 - `--no-config` (`json`, `yaml`, `toml`, `ini`, `cfg`, etc.)
-- `--no-scripts`: exclude shell scripts and `scripts/` directory (`*sh`, `bat`, `ps1`, `scripts/` dir, etc.)
 - `--no-web` (`html*`, stylesheets, `*js*`, `ts*`, etc.)  // This would be the first flag overlapping another flag (e.g., `--no-style`). I don‘t know if this hurts product precision.
 
 ## P1 — Filesystem features breadth (core)

--- a/src/prin/cli_common.py
+++ b/src/prin/cli_common.py
@@ -26,10 +26,12 @@ from prin.defaults import (
     DEFAULT_MAX_DEPTH,
     DEFAULT_MIN_DEPTH,
     DEFAULT_NO_DOCS,
-    DEFAULT_NO_STYLESHEETS,
     DEFAULT_NO_EXCLUDE,
     DEFAULT_NO_IGNORE,
+    DEFAULT_NO_SCRIPTS,
+    DEFAULT_NO_STYLESHEETS,
     DEFAULT_ONLY_HEADERS,
+    DEFAULT_SCRIPT_EXCLUSIONS,
     DEFAULT_STYLESHEET_EXTENSIONS,
     DEFAULT_TAG,
     DEFAULT_TAG_CHOICES,
@@ -75,6 +77,7 @@ class Context:
     include_dependencies: bool = DEFAULT_INCLUDE_DEPENDENCIES
     include_binary: bool = DEFAULT_INCLUDE_BINARY
     no_docs: bool = DEFAULT_NO_DOCS
+    no_scripts: bool = DEFAULT_NO_SCRIPTS
     no_stylesheets: bool = DEFAULT_NO_STYLESHEETS
     include_empty: bool = DEFAULT_INCLUDE_EMPTY
     include_hidden: bool = DEFAULT_INCLUDE_HIDDEN
@@ -128,6 +131,9 @@ class Context:
 
         if self.no_docs:
             exclusions.extend(DEFAULT_DOC_EXTENSIONS)
+
+        if self.no_scripts:
+            exclusions.extend(DEFAULT_SCRIPT_EXCLUSIONS)
 
         if self.no_stylesheets:
             exclusions.extend(DEFAULT_STYLESHEET_EXTENSIONS)
@@ -241,6 +247,12 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         action="store_true",
         help=f"Exclude {', '.join(DEFAULT_DOC_EXTENSIONS)} files.",
         default=DEFAULT_NO_DOCS,
+    )
+    parser.add_argument(
+        "--no-scripts",
+        action="store_true",
+        help="Exclude shell and automation scripts (e.g. *.sh, *.ps1, *.bat) and scripts/ directories.",
+        default=DEFAULT_NO_SCRIPTS,
     )
     parser.add_argument(
         "--no-style",
@@ -365,6 +377,7 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         include_dependencies=bool(args.include_dependencies),
         include_binary=bool(args.include_binary),
         no_docs=bool(args.no_docs),
+        no_scripts=bool(args.no_scripts),
         no_stylesheets=bool(args.no_stylesheets),
         include_empty=bool(args.include_empty),
         only_headers=bool(args.only_headers),

--- a/src/prin/defaults.py
+++ b/src/prin/defaults.py
@@ -99,6 +99,27 @@ DEFAULT_STYLESHEET_EXTENSIONS: list[Glob] = [
 ]
 
 
+DEFAULT_SCRIPT_EXCLUSIONS: list[Pattern] = [
+    re.compile(r"(^|/)scripts(/|$)"),
+    # POSIX shells
+    Glob("*.sh"),
+    Glob("*.bash"),
+    Glob("*.zsh"),
+    Glob("*.ksh"),
+    Glob("*.csh"),
+    Glob("*.tcsh"),
+    Glob("*.fish"),
+    # Windows automation
+    Glob("*.bat"),
+    Glob("*.cmd"),
+    Glob("*.ps1"),
+    Glob("*.psm1"),
+    Glob("*.psd1"),
+    # Modern cross-platform shells
+    Glob("*.nu"),
+]
+
+
 DEFAULT_TEST_EXCLUSIONS: list[Pattern] = [
     re.compile(r".*\.test(\..+)?"),
     re.compile(r"tests?/"),
@@ -253,6 +274,7 @@ DEFAULT_INCLUDE_DEPENDENCIES = True
 DEFAULT_INCLUDE_BINARY = False
 DEFAULT_NO_DOCS = False
 DEFAULT_NO_STYLESHEETS = False
+DEFAULT_NO_SCRIPTS = False
 DEFAULT_INCLUDE_EMPTY = False
 DEFAULT_ONLY_HEADERS = False
 DEFAULT_EXTENSIONS_FILTER = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ class VFS(NamedTuple):
     build_dependency_files: dict[str, str]
     dependency_spec_files: dict[str, str]
     stylesheet_files: dict[str, str]
+    script_files: dict[str, str]
     artifact_files: dict[str, str]
     cache_files: dict[str, str]
     log_files: dict[str, str]
@@ -137,6 +138,12 @@ def fs_root() -> VFS:
         "assets/styles/postcss.postcss": ":root {\n  --font: 'Inter';\n}\n",
         "assets/styles/sugar.sss": ":root\n  color: #123\n",
     }
+    script_files: dict[str, str] = {
+        "scripts/deploy.sh": "#!/usr/bin/env bash\necho 'deploy'\n",
+        "scripts/setup.ps1": "Write-Host 'setup'\n",
+        "scripts/windows/install.bat": "@echo off\necho install\n",
+        "tools/run.nu": "echo 'nu script'\n",
+    }
     artifact_files: dict[str, str] = {
         "build/artifact.o": "OBJ\n",
         "dist/regular.js": "console.log('dist/regular.js');\n",  # Should be excluded because of the dist/ dir.
@@ -172,6 +179,7 @@ def fs_root() -> VFS:
         build_dependency_files,
         dependency_spec_files,
         stylesheet_files,
+        script_files,
         artifact_files,
         cache_files,
         log_files,
@@ -195,6 +203,7 @@ def fs_root() -> VFS:
         **build_dependency_files,
         **dependency_spec_files,
         **stylesheet_files,
+        **script_files,
         **artifact_files,
         **cache_files,
         **log_files,
@@ -249,6 +258,7 @@ def fs_root() -> VFS:
             build_dependency_files=build_dependency_files,
             dependency_spec_files=dependency_spec_files,
             stylesheet_files=stylesheet_files,
+            script_files=script_files,
             artifact_files=artifact_files,
             cache_files=cache_files,
             log_files=log_files,

--- a/tests/test_scripts_flag.py
+++ b/tests/test_scripts_flag.py
@@ -1,0 +1,70 @@
+"""Tests for --no-scripts flag."""
+
+from prin.adapters.filesystem import FileSystemSource
+from prin.cli_common import Context, parse_common_args
+from prin.core import DepthFirstPrinter, StringWriter
+from prin.defaults import DEFAULT_SCRIPT_EXCLUSIONS
+from prin.formatters import XmlFormatter
+
+
+def _run_prin(ctx, root):
+    source = FileSystemSource(anchor=root)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", None, writer)
+    return writer.text()
+
+
+def test_scripts_included_by_default(fs_root):
+    ctx = parse_common_args(["", str(fs_root.root)])
+    assert ctx.no_scripts is False
+    for pattern in DEFAULT_SCRIPT_EXCLUSIONS:
+        assert pattern not in ctx.exclusions
+
+    output = _run_prin(ctx, fs_root.root)
+    for path in fs_root.script_files:
+        assert path in output
+
+
+def test_no_scripts_flag_excludes_scripts(fs_root):
+    ctx = parse_common_args(["--no-scripts", "", str(fs_root.root)])
+    assert ctx.no_scripts is True
+    for pattern in DEFAULT_SCRIPT_EXCLUSIONS:
+        assert pattern in ctx.exclusions
+
+    output = _run_prin(ctx, fs_root.root)
+    for path in fs_root.script_files:
+        assert path not in output
+
+
+def test_scripts_directory_excluded(fs_root):
+    ctx = parse_common_args(["--no-scripts", "", str(fs_root.root)])
+    output = _run_prin(ctx, fs_root.root)
+
+    assert "scripts/deploy.sh" not in output
+    assert "scripts/setup.ps1" not in output
+
+
+def test_explicit_script_is_included(fs_root):
+    explicit_path = fs_root.root / "scripts/deploy.sh"
+    ctx = Context(no_scripts=True)
+    source = FileSystemSource(anchor=explicit_path)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", explicit_path, writer)
+    output = writer.text()
+
+    assert "scripts/deploy.sh" in output
+    assert "echo 'deploy'" in output
+
+
+def test_no_exclude_overrides_no_scripts(fs_root):
+    ctx = parse_common_args(["--no-scripts", "--no-exclude", "", str(fs_root.root)])
+    assert ctx.no_exclude is True
+    assert ctx.exclusions == []
+
+    output = _run_prin(ctx, fs_root.root)
+    for path in fs_root.script_files:
+        assert path in output


### PR DESCRIPTION
## Summary
- add the --no-scripts CLI flag backed by DEFAULT_SCRIPT_EXCLUSIONS and wiring through Context
- extend the filesystem test fixture and create coverage for the new filter semantics
- document the flag, update parities, and remove the completed item from the roadmap

## Testing
- ./test.sh tests/test_scripts_flag.py tests/test_stylesheet_flag.py

------
https://chatgpt.com/codex/tasks/task_e_68dedb6b4e608332b6406f6c7df17144