### PR TITLE
Implement no-config roadmap item

### DIFF
--- a/PARITIES.md
+++ b/PARITIES.md
@@ -45,17 +45,18 @@ See "Maintaining `PARITIES.md`" section at the bottom of this file for detailed 
 #### Members
 - `README.md`: CLI Options; Output Control; Sane Defaults for LLM Input
 - `src/prin/cli_common.py`: `parse_common_args(...)` (all flags), `_expand_cli_aliases`; `Context` dataclass (all flag-derived fields, incl. `pattern`, `paths`)
-- `src/prin/defaults.py`: CLI-related `DEFAULT_*` (choices/booleans/patterns; includes category sets such as exclusions, lock/dependency/docs/binary/test/script/stylesheets, hidden)
+- `src/prin/defaults.py`: CLI-related `DEFAULT_*` (choices/booleans/patterns; includes category sets such as exclusions, lock/dependency/docs/config/binary/test/script/stylesheets, hidden)
 - `src/prin/core.py`: `DepthFirstPrinter._set_from_context` (printing-related fields)
 - `src/prin/adapters/*`: `SourceAdapter.configure(Context)` consumes flag-derived config
 - `src/prin/adapters/filesystem.py`: depth handling in `FileSystemSource._walk_dfs`; category/ignore handling in `should_print(...)`
-- `tests/conftest.py`: `fs_root`/`VFS` fixtures with categorized file dicts (e.g., `dependency_spec_files`, `build_dependency_files`)
+- `tests/conftest.py`: `fs_root`/`VFS` fixtures with categorized file dicts (e.g., `dependency_spec_files`, `build_dependency_files`, `config_files`)
 - `tests/test_depth_controls.py`: depth controls behavior
 - `tests/test_dependency_flag.py`: `--no-dependencies` behavior
+- `tests/test_config_flag.py`: `--no-config` behavior
 
 #### Contract
 - One-to-one mapping: each CLI flag maps to exactly one `Context` field and one default in `defaults.py`; `README.md` documents only implemented flags with current semantics.
-- Category toggles (e.g., hidden/lock/docs/binary/tests/dependencies/scripts/stylesheets) are backed by explicit `DEFAULT_*` entries in `defaults.py` and enforced by adapters via `configure(Context)` and `should_print(...)`. See: Set 5 for filter mechanics.
+- Category toggles (e.g., hidden/lock/docs/config/binary/tests/dependencies/scripts/stylesheets) are backed by explicit `DEFAULT_*` entries in `defaults.py` and enforced by adapters via `configure(Context)` and `should_print(...)`. See: Set 5 for filter mechanics.
 - Depth controls (`--max-depth`, `--min-depth`, `--exact-depth`) are consumed by the filesystem adapter; depth is counted from the search root (depth 1 = direct children).
 - Aliases expand only to canonical flags defined here. See: Set 10.
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ See [Development Cycle (Tight TDD Loop)](AGENTS.md) for more details.
 - [x] `--no-dependencies`: Exclude dependency specification files (e.g., package.json, pyproject.toml, requirements.txt, pom.xml, Cargo.toml).
 
 - [x] `-d`, `--no-docs`: Exclude documentation files (e.g., *.md, *.rst, *.txt).
+- [x] `--no-config`: Exclude configuration files (e.g., *.yaml, *.yml, *.toml, *.ini, *.cfg, *.conf, *.properties, *.env, *.editorconfig, *.config, *rc).
 - [x] `--no-scripts`: Exclude shell and automation scripts (e.g., *.sh, *.ps1, *.bat) and `scripts/` directories.
 - [x] `--no-style`, `--no-css`: Exclude stylesheet files (e.g., *.css, *.scss, *.sass, *.less, *.styl, *.stylus, *.pcss, *.postcss, *.sss).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -27,8 +27,7 @@ Guiding principle: maximize filesystem feature breadth and polish before investi
   * .a - Static library
   * .otc, .ttc, .pfb, .pfm - Additional font files (.otf, .ttf, .woff, .woff2, .eot already handled)
 - Detect binary files dynamically like `fd` does.
-- `--no-config` (`json`, `yaml`, `toml`, `ini`, `cfg`, etc.)
-- `--no-web` (`html*`, stylesheets, `*js*`, `ts*`, etc.)  // This would be the first flag overlapping another flag (e.g., `--no-style`). I don‘t know if this hurts product precision.
+- `--no-web` (`html*`, stylesheets, `*js*`, `ts*`, etc.)  // This would be the first flag overlapping another flag (e.g., `--no-style`). I don't know if this hurts product precision.
 
 ## P1 — Filesystem features breadth (core)
 

--- a/src/prin/cli_common.py
+++ b/src/prin/cli_common.py
@@ -10,6 +10,7 @@ from typing import Literal
 
 from prin.defaults import (
     DEFAULT_BINARY_EXCLUSIONS,
+    DEFAULT_CONFIG_EXTENSIONS,
     DEFAULT_DEPENDENCY_EXCLUSIONS,
     DEFAULT_DOC_EXTENSIONS,
     DEFAULT_EXACT_DEPTH,
@@ -25,6 +26,7 @@ from prin.defaults import (
     DEFAULT_LOCK_EXCLUSIONS,
     DEFAULT_MAX_DEPTH,
     DEFAULT_MIN_DEPTH,
+    DEFAULT_NO_CONFIG,
     DEFAULT_NO_DOCS,
     DEFAULT_NO_EXCLUDE,
     DEFAULT_NO_IGNORE,
@@ -77,6 +79,7 @@ class Context:
     include_dependencies: bool = DEFAULT_INCLUDE_DEPENDENCIES
     include_binary: bool = DEFAULT_INCLUDE_BINARY
     no_docs: bool = DEFAULT_NO_DOCS
+    no_config: bool = DEFAULT_NO_CONFIG
     no_scripts: bool = DEFAULT_NO_SCRIPTS
     no_stylesheets: bool = DEFAULT_NO_STYLESHEETS
     include_empty: bool = DEFAULT_INCLUDE_EMPTY
@@ -131,6 +134,9 @@ class Context:
 
         if self.no_docs:
             exclusions.extend(DEFAULT_DOC_EXTENSIONS)
+
+        if self.no_config:
+            exclusions.extend(DEFAULT_CONFIG_EXTENSIONS)
 
         if self.no_scripts:
             exclusions.extend(DEFAULT_SCRIPT_EXCLUSIONS)
@@ -247,6 +253,12 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         action="store_true",
         help=f"Exclude {', '.join(DEFAULT_DOC_EXTENSIONS)} files.",
         default=DEFAULT_NO_DOCS,
+    )
+    parser.add_argument(
+        "--no-config",
+        action="store_true",
+        help=f"Exclude {', '.join(DEFAULT_CONFIG_EXTENSIONS)} files.",
+        default=DEFAULT_NO_CONFIG,
     )
     parser.add_argument(
         "--no-scripts",
@@ -377,6 +389,7 @@ def parse_common_args(argv: list[str] | None = None) -> Context:
         include_dependencies=bool(args.include_dependencies),
         include_binary=bool(args.include_binary),
         no_docs=bool(args.no_docs),
+        no_config=bool(args.no_config),
         no_scripts=bool(args.no_scripts),
         no_stylesheets=bool(args.no_stylesheets),
         include_empty=bool(args.include_empty),

--- a/src/prin/defaults.py
+++ b/src/prin/defaults.py
@@ -99,6 +99,21 @@ DEFAULT_STYLESHEET_EXTENSIONS: list[Glob] = [
 ]
 
 
+DEFAULT_CONFIG_EXTENSIONS: list[Glob] = [
+    Glob("*.yaml"),
+    Glob("*.yml"),
+    Glob("*.toml"),
+    Glob("*.ini"),
+    Glob("*.cfg"),
+    Glob("*.conf"),
+    Glob("*.properties"),
+    Glob("*.env"),
+    Glob("*.editorconfig"),
+    Glob("*.config"),
+    Glob("*rc"),  # Matches .bashrc, .vimrc, .zshrc, etc.
+]
+
+
 DEFAULT_SCRIPT_EXCLUSIONS: list[Pattern] = [
     re.compile(r"(^|/)scripts(/|$)"),
     # POSIX shells
@@ -273,6 +288,7 @@ DEFAULT_INCLUDE_LOCK = False
 DEFAULT_INCLUDE_DEPENDENCIES = True
 DEFAULT_INCLUDE_BINARY = False
 DEFAULT_NO_DOCS = False
+DEFAULT_NO_CONFIG = False
 DEFAULT_NO_STYLESHEETS = False
 DEFAULT_NO_SCRIPTS = False
 DEFAULT_INCLUDE_EMPTY = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ class VFS(NamedTuple):
     dependency_spec_files: dict[str, str]
     stylesheet_files: dict[str, str]
     script_files: dict[str, str]
+    config_files: dict[str, str]
     artifact_files: dict[str, str]
     cache_files: dict[str, str]
     log_files: dict[str, str]
@@ -144,6 +145,18 @@ def fs_root() -> VFS:
         "scripts/windows/install.bat": "@echo off\necho install\n",
         "tools/run.nu": "echo 'nu script'\n",
     }
+    config_files: dict[str, str] = {
+        "config/settings.yaml": "database: postgres\nport: 5432\n",
+        "config/app.yml": "debug: true\nversion: 1.0.0\n",
+        "config/server.toml": "[server]\nhost = 'localhost'\nport = 8080\n",
+        "config/database.ini": "[database]\nuser = admin\npass = secret\n",
+        "config/app.cfg": "[general]\ntimeout = 30\n",
+        "config/nginx.conf": "server {\n  listen 80;\n}\n",
+        "config/app.properties": "app.name=MyApp\napp.version=1.0\n",
+        "config/envfile.env": "API_KEY=secret123\nDEBUG=true\n",
+        "config/deploy.config": "region=us-west-2\ninstance_type=t2.micro\n",
+        "config/bashrc": "export PATH=$PATH:/usr/local/bin\nalias ll='ls -la'\n",
+    }
     artifact_files: dict[str, str] = {
         "build/artifact.o": "OBJ\n",
         "dist/regular.js": "console.log('dist/regular.js');\n",  # Should be excluded because of the dist/ dir.
@@ -180,6 +193,7 @@ def fs_root() -> VFS:
         dependency_spec_files,
         stylesheet_files,
         script_files,
+        config_files,
         artifact_files,
         cache_files,
         log_files,
@@ -204,6 +218,7 @@ def fs_root() -> VFS:
         **dependency_spec_files,
         **stylesheet_files,
         **script_files,
+        **config_files,
         **artifact_files,
         **cache_files,
         **log_files,
@@ -259,6 +274,7 @@ def fs_root() -> VFS:
             dependency_spec_files=dependency_spec_files,
             stylesheet_files=stylesheet_files,
             script_files=script_files,
+            config_files=config_files,
             artifact_files=artifact_files,
             cache_files=cache_files,
             log_files=log_files,

--- a/tests/test_config_flag.py
+++ b/tests/test_config_flag.py
@@ -1,0 +1,62 @@
+"""Tests for --no-config flag."""
+
+from prin.adapters.filesystem import FileSystemSource
+from prin.cli_common import Context, parse_common_args
+from prin.core import DepthFirstPrinter, StringWriter
+from prin.defaults import DEFAULT_CONFIG_EXTENSIONS
+from prin.formatters import XmlFormatter
+
+
+def _run_prin(ctx, root):
+    source = FileSystemSource(anchor=root)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", None, writer)
+    return writer.text()
+
+
+def test_config_included_by_default(fs_root):
+    ctx = parse_common_args(["", str(fs_root.root)])
+    assert ctx.no_config is False
+    for pattern in DEFAULT_CONFIG_EXTENSIONS:
+        assert pattern not in ctx.exclusions
+
+    output = _run_prin(ctx, fs_root.root)
+    for path in fs_root.config_files:
+        assert path in output
+
+
+def test_no_config_flag_excludes_config_files(fs_root):
+    ctx = parse_common_args(["--no-config", "", str(fs_root.root)])
+    assert ctx.no_config is True
+    for pattern in DEFAULT_CONFIG_EXTENSIONS:
+        assert pattern in ctx.exclusions
+
+    output = _run_prin(ctx, fs_root.root)
+    for path in fs_root.config_files:
+        assert path not in output
+
+
+def test_explicit_config_file_is_included(fs_root):
+    explicit_path = fs_root.root / "config/settings.yaml"
+    ctx = Context(no_config=True)
+    source = FileSystemSource(anchor=explicit_path)
+    source.configure(ctx)
+    writer = StringWriter()
+    printer = DepthFirstPrinter(source, XmlFormatter(), ctx)
+    printer.run_pattern("", explicit_path, writer)
+    output = writer.text()
+
+    assert "config/settings.yaml" in output
+    assert "database: postgres" in output
+
+
+def test_no_exclude_overrides_no_config(fs_root):
+    ctx = parse_common_args(["--no-config", "--no-exclude", "", str(fs_root.root)])
+    assert ctx.no_exclude is True
+    assert ctx.exclusions == []
+
+    output = _run_prin(ctx, fs_root.root)
+    for path in fs_root.config_files:
+        assert path in output


### PR DESCRIPTION
Implement the `--no-config` flag to exclude common configuration files from the output.

---
<a href="https://cursor.com/background-agent?bcId=bc-33164952-9e54-428e-8940-c0a2870921a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33164952-9e54-428e-8940-c0a2870921a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

